### PR TITLE
feat(server): add metadata to return list location

### DIFF
--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -1288,6 +1288,12 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 			l.Err(err).Msgf("querier.GetLocationsByFilters(%+v)", params)
 		} else {
 			for _, loc := range glResp {
+				metadata, err := jsonbToStruct(loc.SourceMetadata)
+				if err != nil {
+					l.Err(err).Msgf("jsonbToStruct(%s)", loc.SourceMetadata)
+					metadata = nil
+				}
+
 				locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
 					LocationUuid: loc.LocationUuid.String(),
 					LocationName: loc.LocationName,
@@ -1302,6 +1308,7 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 					),
 					EnergySource: pb.EnergySource(loc.SourceTypeID),
 					LocationType: pb.LocationType(loc.LocationTypeID),
+					Metadata:     metadata,
 				})
 			}
 		}
@@ -1321,6 +1328,12 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 			l.Err(err).Msgf("querier.GetLocationsByFilters(%+v)", params)
 		} else {
 			for _, loc := range glResp {
+				metadata, err := jsonbToStruct(loc.SourceMetadata)
+				if err != nil {
+					l.Err(err).Msgf("jsonbToStruct(%s)", loc.SourceMetadata)
+					metadata = nil
+				}
+
 				locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
 					LocationUuid: loc.LocationUuid.String(),
 					LocationName: loc.LocationName,
@@ -1335,6 +1348,7 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 					),
 					EnergySource: pb.EnergySource(loc.SourceTypeID),
 					LocationType: pb.LocationType(loc.LocationTypeID),
+					Metadata:     metadata,
 				})
 			}
 		}

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -675,6 +675,8 @@ func TestGetForecastAsTimeseries(t *testing.T) {
 
 func TestListLocationsLocationFilters(t *testing.T) {
 	pivotTime := time.Now().Truncate(time.Minute)
+	metadata, err := structpb.NewStruct(map[string]any{"source": "test"})
+	require.NoError(t, err)
 
 	// Create a bunch of locations
 	var locationUuids []string
@@ -693,7 +695,7 @@ func TestListLocationsLocationFilters(t *testing.T) {
 					EnergySource:           energySource,
 					LocationType:           locType,
 					ValidFromUtc:           timestamppb.New(pivotTime.Add(-time.Hour * 4)),
-					Metadata:               &structpb.Struct{},
+					Metadata:               metadata,
 				})
 				require.NoError(t, err)
 
@@ -800,6 +802,10 @@ func TestListLocationsLocationFilters(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedCount, len(resp.Locations))
+
+				for _, loc := range resp.Locations {
+					require.Equal(t, metadata.AsMap(), loc.Metadata.AsMap())
+				}
 			}
 		})
 	}

--- a/internal/server/postgres/sql/queries/locations.sql
+++ b/internal/server/postgres/sql/queries/locations.sql
@@ -155,7 +155,9 @@ WITH all_locations AS (
         l.location_name,
         l.location_type_id,
         ST_X(l.centroid)::REAL AS longitude,
-        ST_Y(l.centroid)::REAL AS latitude
+        ST_Y(l.centroid)::REAL AS latitude,
+        l.metadata AS location_metadata,
+        ls.metadata AS source_metadata
     FROM loc.sources_mv AS ls
         INNER JOIN loc.locations AS l USING (location_uuid)
         LEFT OUTER JOIN iam.location_policies AS lp USING (location_uuid, source_type_id)
@@ -185,7 +187,8 @@ WITH contained_locations AS (
         l.location_name,
         l.location_type_id,
         l.geom,
-        l.centroid
+        l.centroid,
+        l.metadata
     FROM loc.locations AS l
         INNER JOIN
             loc.locations AS l_outer ON ST_WITHIN(
@@ -205,7 +208,9 @@ all_locations AS (
         l.location_name,
         l.location_type_id,
         ST_X(l.centroid)::REAL AS longitude,
-        ST_Y(l.centroid)::REAL AS latitude
+        ST_Y(l.centroid)::REAL AS latitude,
+        l.metadata AS location_metadata,
+        ls.metadata AS source_metadata
     FROM loc.sources_mv AS ls
         INNER JOIN contained_locations AS l USING (location_uuid)
         LEFT OUTER JOIN iam.location_policies AS lp USING (location_uuid, source_type_id)

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -448,6 +448,7 @@ message ListLocationsResponse {
     LocationType location_type = 4;
     uint64 effective_capacity_watts = 5;
     LatLng latlng = 6;
+    google.protobuf.Struct metadata = 7;
   }
 
   repeated LocationSummary locations = 1;


### PR DESCRIPTION
I have added the metadata to return object of list all locations.
This returns the metadata from the `source` not the `location` see #25 


- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes?.
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make gen` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?


