### PR TITLE
feat(server): Add GetLatestForecasts RPC

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,5 +27,5 @@ RUN \
 FROM gcr.io/distroless/static-debian11 AS app
 
 COPY --from=build /go/src/app/bin/dp-server /
-CMD ["/dp-server"]
+ENTRYPOINT ["/dp-server"]
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,8 +52,8 @@ func main() {
 		log.Fatal().Err(err).Msgf("net.Listen({tcp: %d})", conf.GetInt("port"))
 	}
 
-	// Choose the server implementation based on the environment
-	databaseUrl := strings.ToLower(conf.GetString("dburl"))
+	// Remove any errant quotation marks from the dburl
+	databaseUrl := strings.Trim(conf.GetString("dburl"), "\"")
 
 	var (
 		dataServerImpl  pb.DataPlatformDataServiceServer

--- a/internal/server/dummy/dataserverimpl.go
+++ b/internal/server/dummy/dataserverimpl.go
@@ -384,10 +384,36 @@ func (d *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 // GetLatestForecasts implements dp.DataPlatformDataServiceServer.
 func (d *DataPlatformDataServiceServerImpl) GetLatestForecasts(
-	context.Context,
-	*pb.GetLatestForecastsRequest,
+	ctx context.Context,
+	req *pb.GetLatestForecastsRequest,
 ) (*pb.GetLatestForecastsResponse, error) {
-	panic("unimplemented")
+	forecasts := make([]*pb.GetLatestForecastsResponse_Forecast, 5)
+
+	if req.PivotTimestampUtc == nil {
+		req.PivotTimestampUtc = timestamppb.New(time.Now().UTC())
+	}
+
+	for i := range forecasts {
+		forecasts[i] = &pb.GetLatestForecastsResponse_Forecast{
+			InitializationTimestampUtc: timestamppb.New(
+				req.PivotTimestampUtc.AsTime().Add(-time.Duration(i) * time.Hour),
+			),
+			CreatedTimestampUtc: timestamppb.New(
+				req.PivotTimestampUtc.AsTime().
+					Add(-time.Duration(i) * time.Hour).
+					Truncate(time.Hour),
+			),
+			Forecaster: &pb.Forecaster{
+				ForecasterName:    "DummyForecaster",
+				ForecasterVersion: "v1.0.0",
+			},
+			LocationUuid: uuid.New().String(),
+		}
+	}
+
+	return &pb.GetLatestForecastsResponse{
+		Forecasts: forecasts,
+	}, nil
 }
 
 // GetLocation implements dp.DataPlatformDataServiceServer.

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -156,7 +156,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 	gsParams := db.GetLocationSourceAtTimestampParams{
 		LocationUuid:   locationUuid,
 		SourceTypeID:   int16(req.EnergySource.Number()),
-		AtTimestampUtc: pgtype.Timestamp{Time: req.InitTimeUtc.AsTime(), Valid: true},
+		AtTimestampUtc: pgtype.Timestamp{Time: req.InitTimeUtc.AsTime().UTC(), Valid: true},
 	}
 
 	dbSource, err := querier.GetLocationSourceAtTimestamp(ctx, gsParams)
@@ -253,10 +253,48 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 }
 
 func (s *DataPlatformDataServiceServerImpl) GetLatestForecasts(
-	context.Context,
-	*pb.GetLatestForecastsRequest,
+	ctx context.Context,
+	req *pb.GetLatestForecastsRequest,
 ) (*pb.GetLatestForecastsResponse, error) {
-	panic("unimplemented")
+	l := zerolog.Ctx(ctx)
+	querier := db.New(ix.GetTxFromContext(ctx))
+
+	if req.PivotTimestampUtc == nil {
+		req.PivotTimestampUtc = timestamppb.New(time.Now().UTC().Truncate(time.Minute))
+	}
+
+	glfprms := db.GetLatestForecastsAtHorizonSincePivotParams{
+		LocationUuid:   uuid.MustParse(req.LocationUuid),
+		SourceTypeID:   int16(req.EnergySource),
+		PivotTimestamp: pgtype.Timestamp{Time: req.PivotTimestampUtc.AsTime(), Valid: true},
+	}
+
+	dbListForecasts, err := querier.GetLatestForecastsAtHorizonSincePivot(ctx, glfprms)
+	if err != nil {
+		l.Err(err).Msgf("querier.GetLatestForecastsAtHorizonSincePivot(%+v)", glfprms)
+
+		return nil, status.Errorf(
+			codes.NotFound,
+			"No forecasts found for location '%s'. Ensure location exists.",
+			req.LocationUuid,
+		)
+	}
+
+	forecasts := make([]*pb.GetLatestForecastsResponse_Forecast, len(dbListForecasts))
+	for i, fc := range dbListForecasts {
+		forecasts[i] = &pb.GetLatestForecastsResponse_Forecast{
+			InitializationTimestampUtc: timestamppb.New(fc.InitTimeUtc.Time),
+			Forecaster: &pb.Forecaster{
+				ForecasterName:    fc.ForecasterName,
+				ForecasterVersion: fc.ForecasterVersion,
+			},
+			LocationUuid: fc.LocationUuid.String(),
+		}
+	}
+
+	return &pb.GetLatestForecastsResponse{
+		Forecasts: forecasts,
+	}, nil
 }
 
 func (s *DataPlatformDataServiceServerImpl) CreateForecaster(

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -1090,6 +1090,118 @@ func TestCreateForecast(t *testing.T) {
 	require.NotNil(t, resp)
 }
 
+func TestGetLatestForecasts(t *testing.T) {
+	pivotTime := time.Date(2022, 1, 5, 12, 0, 0, 0, time.UTC)
+	metadata, err := structpb.NewStruct(map[string]any{"source": "test"})
+	require.NoError(t, err)
+
+	// Create a site to attach the forecasts to
+	siteResp, err := dc.CreateLocation(t.Context(), &pb.CreateLocationRequest{
+		LocationName:           "test_get_latest_forecasts_site",
+		GeometryWkt:            "POINT(-0.6 51.8)",
+		EffectiveCapacityWatts: 1000000,
+		Metadata:               metadata,
+		EnergySource:           pb.EnergySource_ENERGY_SOURCE_SOLAR,
+		LocationType:           pb.LocationType_LOCATION_TYPE_SITE,
+		ValidFromUtc:           timestamppb.New(pivotTime.Add(-time.Hour * 24)),
+	})
+	require.NoError(t, err)
+
+	// Create forecaster
+	forecasterResp, err := dc.CreateForecaster(t.Context(), &pb.CreateForecasterRequest{
+		Name:    "test_get_latest_forecasts_forecaster",
+		Version: "v1",
+	})
+	require.NoError(t, err)
+	// Update the forecaster a couple of times
+	for i := range 2 {
+		_, err = dc.UpdateForecaster(t.Context(), &pb.UpdateForecasterRequest{
+			Name:       forecasterResp.Forecaster.ForecasterName,
+			NewVersion: fmt.Sprintf("v%d", i+2),
+		})
+		require.NoError(t, err)
+	}
+
+	yields := make([]*pb.CreateForecastRequest_ForecastValue, 10)
+	for i := range yields {
+		yields[i] = &pb.CreateForecastRequest_ForecastValue{
+			HorizonMins: uint32(i * 30),
+			P50Fraction: 0.5 + float32(i)*0.05,
+			P10Fraction: 0.4 + float32(i)*0.05,
+			P90Fraction: 0.6 + float32(i)*0.05,
+			Metadata:    metadata,
+		}
+	}
+
+	// Make a forecast at differring times for each forecaster
+	for i := range 3 {
+		req := &pb.CreateForecastRequest{
+			LocationUuid: siteResp.LocationUuid,
+			Forecaster: &pb.Forecaster{
+				ForecasterName:    forecasterResp.Forecaster.ForecasterName,
+				ForecasterVersion: fmt.Sprintf("v%d", i+1),
+			},
+			EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+			InitTimeUtc:  timestamppb.New(pivotTime.Add(time.Duration(-i) * time.Hour)),
+			Values:       yields,
+		}
+		_, err = dc.CreateForecast(t.Context(), req)
+		require.NoError(t, err)
+	}
+
+	testcases := []struct {
+		name              string
+		req               *pb.GetLatestForecastsRequest
+		expectedInitTimes []time.Time
+	}{
+		{
+			name: "Should return latest forecasts for all forecasters",
+			req: &pb.GetLatestForecastsRequest{
+				LocationUuid:      siteResp.LocationUuid,
+				EnergySource:      pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				PivotTimestampUtc: timestamppb.New(pivotTime),
+			},
+			expectedInitTimes: []time.Time{
+				pivotTime,
+				pivotTime.Add(-time.Hour * 1),
+				pivotTime.Add(-time.Hour * 2),
+			},
+		},
+		{
+			name: "Should return older forecasts for earlier pivot time",
+			req: &pb.GetLatestForecastsRequest{
+				LocationUuid:      siteResp.LocationUuid,
+				EnergySource:      pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				PivotTimestampUtc: timestamppb.New(pivotTime.Add(-time.Minute * 55)),
+			},
+			expectedInitTimes: []time.Time{
+				pivotTime.Add(-time.Hour * 1),
+				pivotTime.Add(-time.Hour * 2),
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := dc.GetLatestForecasts(t.Context(), tt.req)
+			if strings.Contains(tt.name, "Shouldn't") {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Equal(t, len(tt.expectedInitTimes), len(resp.Forecasts))
+
+				actualTimes := make([]time.Time, len(resp.Forecasts))
+				for i, forecast := range resp.Forecasts {
+					actualTimes[i] = forecast.InitializationTimestampUtc.AsTime()
+				}
+
+				require.Equal(t, tt.expectedInitTimes, actualTimes)
+			}
+		})
+	}
+}
+
 // --- BENCHMARKS ---------------------------------------------------------------------------------
 
 // BenchmarkPostgresClient runs benchmarks against the Postgres client.

--- a/internal/server/postgres/sql/queries/predictions.sql
+++ b/internal/server/postgres/sql/queries/predictions.sql
@@ -98,9 +98,9 @@ INSERT INTO pred.predicted_generation_values (
     $1, $2, $3, $4, $5, $6, $7
 );
 
--- name: GetLatestForecastAtHorizonSincePivot :one
-/* GetLatestForecastAtHorizonSincePivot retrieves the latest forecast for a given location,
- * source type, and forecaster. Only forecasts that are older than the pivot time
+-- name: GetLatestForecastsAtHorizonSincePivot :many
+/* GetLatestForecastAtHorizonSincePivot retrieves the latest forecasts for a given location
+ * and source type made by all forecasters. Only forecasts that are older than the pivot time
  * minus the specified horizon are considered.
  */
 SELECT
@@ -108,13 +108,15 @@ SELECT
     f.init_time_utc,
     f.source_type_id,
     f.location_uuid,
-    f.forecaster_id
+    fr.forecaster_name,
+    fr.forecaster_version,
+    UUIDV7_EXTRACT_TIMESTAMP(f.forecast_uuid) AS created_at_utc
 FROM pred.forecasts AS f
+    INNER JOIN pred.forecasters AS fr USING (forecaster_id)
 WHERE f.location_uuid = $1
     AND f.source_type_id = $2
-    AND f.forecaster_id = $3
     AND f.init_time_utc <= sqlc.arg(pivot_timestamp)::TIMESTAMP - MAKE_INTERVAL(mins => sqlc.arg(horizon_mins)::INTEGER)
-ORDER BY f.init_time_utc DESC LIMIT 1;
+ORDER BY f.init_time_utc DESC;
 
 -- name: ListForecasts :many
 /* ListForecasts retrieves all the forecasts for a given location, source type, and forecaster

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -145,27 +145,24 @@ message GetForecastAtTimestampResponse {
 
 
 message GetLatestForecastsRequest {
-  repeated string location_uuids = 1 [
-    (buf.validate.field).repeated.min_items = 1,
-    (buf.validate.field).repeated.max_items = 1000,
-    (buf.validate.field).repeated.unique = true,
-    (buf.validate.field).repeated.items = {
-      string: {uuid: true}
-    }
+  string location_uuid = 1 [
+    (buf.validate.field).string.uuid = true
   ];
   EnergySource energy_source = 2;
   /* The time to search backwards from to find the 'latest' forecast.
    * If not specified, the current time will be used.
    */
-  google.protobuf.Timestamp pivot_timestamp_utc = 3;
+  google.protobuf.Timestamp pivot_timestamp_utc = 3 [
+    (buf.validate.field).timestamp = { gt: { seconds: 112000000}, lt_now: true }
+  ];
 }
 
 message GetLatestForecastsResponse {
   message Forecast {
     google.protobuf.Timestamp initialization_timestamp_utc = 1;
-    Forecaster forecaster = 2;
-    string location_uuid = 3;
-    string location_name = 4;
+    google.protobuf.Timestamp created_timestamp_utc = 2;
+    Forecaster forecaster = 3;
+    string location_uuid = 4;
   }
 
   repeated GetLatestForecastsResponse.Forecast forecasts = 1;
@@ -207,7 +204,13 @@ message UpdateForecasterResponse {
 message ListForecastersRequest {
   // Optional filter to only return forecasters from a given set.
   // If empty, all forecasters will be returned.
-  repeated string forecaster_names_filter = 1;
+  repeated string forecaster_names_filter = 1 [
+    (buf.validate.field).repeated.max_items = 100,
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items = {
+      string: {min_len: 2, max_len: 100},
+    }
+  ];
   // If true, only the latest version of each forecaster will be returned.
   bool latest_versions_only = 2;
 }


### PR DESCRIPTION
- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes?.
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make gen` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

Adds `GetLatestForecasts` route as per #18. Also fixes a parsing issue with the DATABASE_URL environment variable.