### PR TITLE
feat(server): GetLatestObservations multiple locs

### DIFF
--- a/internal/server/dummy/dataserverimpl.go
+++ b/internal/server/dummy/dataserverimpl.go
@@ -317,19 +317,27 @@ func (d *DataPlatformDataServiceServerImpl) CreateObservations(
 	return &pb.CreateObservationsResponse{}, nil
 }
 
-// GetLatestObservation implements dp.DataPlatformDataServiceServer.
-func (s *DataPlatformDataServiceServerImpl) GetLatestObservation(
+// GetLatestObservations implements dp.DataPlatformDataServiceServer.
+func (s *DataPlatformDataServiceServerImpl) GetLatestObservations(
 	ctx context.Context,
-	req *pb.GetLatestObservationRequest,
-) (*pb.GetLatestObservationResponse, error) {
+	req *pb.GetLatestObservationsRequest,
+) (*pb.GetLatestObservationsResponse, error) {
 	if req.PivotTimestampUtc == nil {
 		req.PivotTimestampUtc = timestamppb.New(time.Now().UTC())
 	}
 
-	return &pb.GetLatestObservationResponse{
-		TimestampUtc:           req.PivotTimestampUtc,
-		ValueFraction:          0.75,
-		EffectiveCapacityWatts: 150e6,
+	observations := make([]*pb.GetLatestObservationsResponse_Observation, len(req.LocationUuids))
+	for i := range observations {
+		observations[i] = &pb.GetLatestObservationsResponse_Observation{
+			LocationUuid:           req.LocationUuids[i],
+			TimestampUtc:           req.PivotTimestampUtc,
+			ValueFraction:          0.75,
+			EffectiveCapacityWatts: 150e6,
+		}
+	}
+
+	return &pb.GetLatestObservationsResponse{
+		Observations: observations,
 	}, nil
 }
 

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -903,10 +903,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 	return &pb.CreateObservationsResponse{}, nil
 }
 
-func (s *DataPlatformDataServiceServerImpl) GetLatestObservation(
+func (s *DataPlatformDataServiceServerImpl) GetLatestObservations(
 	ctx context.Context,
-	req *pb.GetLatestObservationRequest,
-) (*pb.GetLatestObservationResponse, error) {
+	req *pb.GetLatestObservationsRequest,
+) (*pb.GetLatestObservationsResponse, error) {
 	l := zerolog.Ctx(ctx)
 	querier := db.New(ix.GetTxFromContext(ctx))
 
@@ -915,31 +915,50 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestObservation(
 		req.PivotTimestampUtc = timestamppb.New(time.Now().UTC().Truncate(time.Minute))
 	}
 
-	goprms := db.GetLatestObservationParams{
-		GeometryUuid: uuid.MustParse(req.LocationUuid),
-		SourceTypeID: int16(req.EnergySource),
-		ObserverName: req.ObserverName,
-		PivotTimeUtc: pgtype.Timestamp{Time: req.PivotTimestampUtc.AsTime(), Valid: true},
+	locUuids := make([]uuid.UUID, len(req.LocationUuids))
+	for i, locStr := range req.LocationUuids {
+		locUuids[i] = uuid.MustParse(locStr)
 	}
 
-	dbObs, err := querier.GetLatestObservation(ctx, goprms)
+	goprms := db.GetLatestObservationsParams{
+		GeometryUuids: locUuids,
+		SourceTypeID:  int16(req.EnergySource),
+		ObserverName:  req.ObserverName,
+		PivotTimeUtc:  pgtype.Timestamp{Time: req.PivotTimestampUtc.AsTime(), Valid: true},
+	}
+
+	dbObs, err := querier.GetLatestObservations(ctx, goprms)
 	if err != nil {
 		l.Err(err).Msgf("querier.GetLatestObservation(%+v)", goprms)
 
 		return nil, status.Error(
-			codes.NotFound,
-			"No observations found. Ensure location and observer exist, and observations have been created.",
+			codes.Internal,
+			"Backend communication error. See logs for details.",
 		)
 	}
 
-	return &pb.GetLatestObservationResponse{
-		TimestampUtc:  timestamppb.New(dbObs.ObservationTimestampUtc.Time),
-		ValueFraction: float32(dbObs.ValueSip) / 30000.0,
-		EffectiveCapacityWatts: uint64(
-			dbObs.CapacityIncLimit,
-		) * uint64(
-			math.Pow10(int(dbObs.CapacityUnitPrefixFactor)),
-		),
+	observations := make([]*pb.GetLatestObservationsResponse_Observation, len(dbObs))
+	for i, obs := range dbObs {
+		observations[i] = &pb.GetLatestObservationsResponse_Observation{
+			LocationUuid:  obs.GeometryUuid.String(),
+			TimestampUtc:  timestamppb.New(obs.ObservationTimestampUtc.Time),
+			ValueFraction: float32(obs.ValueSip) / 30000.0,
+			EffectiveCapacityWatts: uint64(
+				obs.CapacityIncLimit,
+			) * uint64(
+				math.Pow10(int(obs.CapacityUnitPrefixFactor)),
+			),
+		}
+	}
+
+	l.Debug().
+		Int16("dp.source.type_id", goprms.SourceTypeID).
+		Int("dp.geometry.count", len(req.LocationUuids)).
+		Int("dp.observations.count", len(observations)).
+		Msg("found observations")
+
+	return &pb.GetLatestObservationsResponse{
+		Observations: observations,
 	}, nil
 }
 

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -1012,12 +1012,12 @@ func TestGetObservationsAsTimeseries(t *testing.T) {
 	}
 }
 
-func TestGetLatestObservation(t *testing.T) {
+func TestGetLatestObservations(t *testing.T) {
 	pivotTime := time.Now().Truncate(time.Minute)
 
 	// Create a site to attach the observations to
 	siteResp, err := dc.CreateLocation(t.Context(), &pb.CreateLocationRequest{
-		LocationName:           "test_get_latest_observation_site",
+		LocationName:           "test_get_latest_observations_site_1",
 		GeometryWkt:            "POINT(-20.25 57.5)",
 		EffectiveCapacityWatts: 1000000,
 		Metadata:               &structpb.Struct{},
@@ -1029,7 +1029,7 @@ func TestGetLatestObservation(t *testing.T) {
 
 	// Create an observer to make the observations
 	obsResp, err := dc.CreateObserver(t.Context(), &pb.CreateObserverRequest{
-		Name: "test_get_latest_observation_observer",
+		Name: "test_get_latest_observations_observer",
 	})
 	require.NoError(t, err)
 
@@ -1053,56 +1053,60 @@ func TestGetLatestObservation(t *testing.T) {
 	require.NoError(t, err)
 
 	testcases := []struct {
-		name             string
-		req              *pb.GetLatestObservationRequest
-		expectedFraction float32
+		name              string
+		req               *pb.GetLatestObservationsRequest
+		expectedFractions []float32
 	}{
 		{
-			name: "Should get latest observation",
-			req: &pb.GetLatestObservationRequest{
-				LocationUuid: siteResp.LocationUuid,
-				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
-				ObserverName: obsResp.ObserverName,
+			name: "Should get latest observations",
+			req: &pb.GetLatestObservationsRequest{
+				LocationUuids: []string{siteResp.LocationUuid},
+				EnergySource:  pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				ObserverName:  obsResp.ObserverName,
 			},
-			expectedFraction: 0.5,
+			expectedFractions: []float32{0.5},
 		},
 		{
 			name: "Should get earlier observation before cutoff",
-			req: &pb.GetLatestObservationRequest{
-				LocationUuid:      siteResp.LocationUuid,
+			req: &pb.GetLatestObservationsRequest{
+				LocationUuids:     []string{siteResp.LocationUuid},
 				EnergySource:      pb.EnergySource_ENERGY_SOURCE_SOLAR,
 				ObserverName:      obsResp.ObserverName,
 				PivotTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 1).Add(-time.Second)),
 			},
-			expectedFraction: 0.3,
+			expectedFractions: []float32{0.3},
 		},
 		{
-			name: "Shouldn't fetch for non-existent observer",
-			req: &pb.GetLatestObservationRequest{
-				LocationUuid: siteResp.LocationUuid,
-				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
-				ObserverName: "non_existent_observer",
+			name: "Should fetch no rows for non-existent observer",
+			req: &pb.GetLatestObservationsRequest{
+				LocationUuids: []string{siteResp.LocationUuid},
+				EnergySource:  pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				ObserverName:  "non_existent_observer",
 			},
 		},
 		{
-			name: "Shouldn't fetch for non-existent location",
-			req: &pb.GetLatestObservationRequest{
-				LocationUuid: "non_existent_location",
-				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
-				ObserverName: obsResp.ObserverName,
+			name: "Should fetch no rows for non-existent location",
+			req: &pb.GetLatestObservationsRequest{
+				LocationUuids: []string{uuid.New().String()},
+				EnergySource:  pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				ObserverName:  obsResp.ObserverName,
 			},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := dc.GetLatestObservation(t.Context(), tc.req)
+			resp, err := dc.GetLatestObservations(t.Context(), tc.req)
 			if strings.Contains(tc.name, "Shouldn't") {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
-				require.Equal(t, tc.expectedFraction, resp.ValueFraction)
+
+				for i, obs := range resp.Observations {
+					t.Log(obs)
+					require.Equal(t, tc.expectedFractions[i], obs.ValueFraction)
+				}
 			}
 		})
 	}

--- a/internal/server/postgres/sql/queries/observations.sql
+++ b/internal/server/postgres/sql/queries/observations.sql
@@ -84,28 +84,43 @@ WHERE
     AND og.observation_timestamp_utc BETWEEN sqlc.arg(start_time_utc)::TIMESTAMP AND sqlc.arg(end_time_utc)::TIMESTAMP
     AND sh.sys_period @> og.observation_timestamp_utc;
 
--- name: GetLatestObservation :one
-/* GetLatestObservation gets the latest observation for a given location, source type, and observer.
- * The value is returned as a 16-bit integer, with 0 representing 0%
+-- name: GetLatestObservations :many
+/* GetLatestObservations gets the latest observations for a given location set, source type, and
+ * observer. The value is returned as a 16-bit integer, with 0 representing 0%
  * and 30000 representing 100% of capacity.
  */
+WITH ranked_observations AS (
+    SELECT
+        og.geometry_uuid,
+        og.source_type_id,
+        og.observation_timestamp_utc,
+        og.value_sip,
+        sh.capacity_limit_sip,
+        sh.capacity,
+        sh.capacity_unit_prefix_factor,
+        ROW_NUMBER() OVER (
+            PARTITION BY og.geometry_uuid, og.source_type_id, o.observer_uuid
+            ORDER BY og.observation_timestamp_utc DESC
+        ) AS rn
+    FROM obs.observed_generation_values AS og
+        INNER JOIN loc.sources_mv AS sh USING (geometry_uuid, source_type_id)
+        INNER JOIN obs.observers AS o USING (observer_uuid)
+    WHERE
+        og.geometry_uuid = ANY(sqlc.arg(geometry_uuids)::UUID [])
+        AND og.source_type_id = $1
+        AND o.observer_name = LOWER(sqlc.arg(observer_name)::TEXT)
+        AND sh.sys_period @> og.observation_timestamp_utc
+        AND og.observation_timestamp_utc <= sqlc.arg(pivot_time_utc)::TIMESTAMP
+)
 SELECT
-    og.geometry_uuid,
-    og.source_type_id,
-    og.observation_timestamp_utc,
-    og.value_sip,
+    geometry_uuid,
+    source_type_id,
+    observation_timestamp_utc,
+    value_sip,
     COALESCE(
-        sh.capacity_limit_sip::REAL * sh.capacity / 30000.0, sh.capacity::REAL
+        capacity_limit_sip::REAL * capacity / 30000.0, capacity::REAL
     )::REAL AS capacity_inc_limit,
-    sh.capacity_unit_prefix_factor
-FROM obs.observed_generation_values AS og
-    INNER JOIN loc.sources_mv AS sh USING (geometry_uuid, source_type_id)
-    INNER JOIN obs.observers AS o USING (observer_uuid)
-WHERE
-    og.geometry_uuid = $1
-    AND og.source_type_id = $2
-    AND o.observer_name = LOWER(sqlc.arg(observer_name)::TEXT)
-    AND sh.sys_period @> og.observation_timestamp_utc
-    AND og.observation_timestamp_utc <= sqlc.arg(pivot_time_utc)::TIMESTAMP
-ORDER BY og.observation_timestamp_utc DESC
-LIMIT 1;
+    capacity,
+    capacity_unit_prefix_factor
+FROM ranked_observations
+WHERE rn = 1;

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -443,10 +443,14 @@ message CreateObservationsRequest {
 message CreateObservationsResponse {}
 
 
-message GetLatestObservationRequest {
-  string location_uuid = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
+message GetLatestObservationsRequest {
+  repeated string location_uuids = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 100,
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items = {
+      string: {uuid: true}
+    }
   ];
   EnergySource energy_source = 2 [
     (buf.validate.field).required = true 
@@ -463,10 +467,15 @@ message GetLatestObservationRequest {
   ];
 }
 
-message GetLatestObservationResponse {
-  google.protobuf.Timestamp timestamp_utc = 1;
-  float value_fraction = 2;
-  uint64 effective_capacity_watts = 3;
+message GetLatestObservationsResponse {
+  message Observation {
+    string location_uuid = 1;
+    google.protobuf.Timestamp timestamp_utc = 2;
+    float value_fraction = 3;
+    uint64 effective_capacity_watts = 4;
+  }
+
+  repeated GetLatestObservationsResponse.Observation observations = 1;
 }
 
 

--- a/proto/ocf/dp/dp-data.service.proto
+++ b/proto/ocf/dp/dp-data.service.proto
@@ -44,7 +44,7 @@ service DataPlatformDataService {
   rpc ListObservers(ListObserversRequest) returns (ListObserversResponse) {}
   rpc CreateObservations(CreateObservationsRequest) returns (CreateObservationsResponse) {}
   /* GetLatestObservation fetches the most recent observation for a given location and observer. */
-  rpc GetLatestObservation(GetLatestObservationRequest) returns (GetLatestObservationResponse) {}
+  rpc GetLatestObservations(GetLatestObservationsRequest) returns (GetLatestObservationsResponse) {}
 
   // --- Analysis ----------------------------------------------------------------
 


### PR DESCRIPTION
- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes?.
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make gen` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

Modifies the GetLAtestObservations route such that multiple locations can be passed to it at once.