### PR TITLE
chore(gen): Add py.typed to python sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ gen.proto.python: ${PROTOC}
         --python_betterproto_opt=typing.310 \
         --python_betterproto_out=gen/python/src/dp_sdk
 	@printf "%s" "$$pyproj" > gen/python/pyproject.toml
+	@touch gen/python/src/dp_sdk/py.typed
 	@echo "$$GEN_PYPROJ" > gen/python/pyproject.toml
 	@echo "Building wheel..."
 	@cd gen/python && echo $$(uv run python -m setuptools_git_versioning) && uv build && cd ../..


### PR DESCRIPTION
- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [ ] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [ ] Have you written new tests for your changes?.
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make gen` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

Adds `py.typed` marker to geenrated python sdk.