### PR TITLE
feat(sdk): Correct imports in wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,19 +158,20 @@ endef
 export GEN_PYPROJ
 
 .PHONY: gen.proto.python
+.PHONY: gen.proto.python
 gen.proto.python: ${PROTOC}
 	@echo "Generating Python client bindings..."
-	@rm -rf gen/python && mkdir -p gen/python/src/dp_sdk
+	@rm -rf gen/python && mkdir -p gen/python/src
 	@uvx --from 'grpcio-tools==1.80.0' --with 'betterproto[compiler]==2.0.0b7' python-grpc-tools-protoc \
 		$$(find proto -iname "*.proto") \
 		-I=proto \
 		-I=$(PROTOC_INCLUDE) \
-		--python_out=gen/python/src/dp_sdk \
-		--pyi_out=gen/python/src/dp_sdk \
-		--grpc_python_out=gen/python/src/dp_sdk
+		--python_out=gen/python/src \
+		--pyi_out=gen/python/src \
+		--grpc_python_out=gen/python/src \
 		--python_betterproto_opt=typing.310 \
-		--python_betterproto_out=gen/python/src/dp_sdk
-	@touch gen/python/src/dp_sdk/py.typed
+		--python_betterproto_out=gen/python/src
+	@find gen/python/src -type d -exec touch {}/__init__.py \;
 	@echo "$$GEN_PYPROJ" > gen/python/pyproject.toml
 	@echo "Building wheel..."
 	@cd gen/python && echo $$(uv run python -m setuptools_git_versioning) && uv build


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Includes the default python grpc codegen in the bindings. Modifies the import path to be from ocf in the python wheel.