### PR TITLE
fix(sql): Swap created/init in latest forecasts route

### DIFF
--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -155,7 +155,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 		// Okay to take the last value as we checked it was monotonically increasing above
 		LastHorizonMins: int32(req.Values[len(req.Values)-1].HorizonMins),
 		Metadata:        req.Metadata,
-		CreatedAtUtc:        timeptrToPgTimestamp(req.CreatedTimestampUtc),
+		CreatedAtUtc:    timeptrToPgTimestamp(req.CreatedTimestampUtc),
 	}
 
 	dbForecast, err := querier.CreateForecast(ctx, cfprms)

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -155,6 +155,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 		// Okay to take the last value as we checked it was monotonically increasing above
 		LastHorizonMins: int32(req.Values[len(req.Values)-1].HorizonMins),
 		Metadata:        req.Metadata,
+		CreatedAtUtc:        timeptrToPgTimestamp(req.CreatedTimestampUtc),
 	}
 
 	dbForecast, err := querier.CreateForecast(ctx, cfprms)

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -1853,6 +1853,7 @@ func TestGetLatestForecasts(t *testing.T) {
 			EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
 			InitTimeUtc:  timestamppb.New(pivotTime.Add(time.Duration(-i) * time.Hour)),
 			Values:       yields,
+			CreatedTimestampUtc: timestamppb.New(pivotTime.Add(time.Duration(-i)*time.Hour + time.Minute)),
 		}
 		_, err = dc.CreateForecast(t.Context(), req)
 		require.NoError(t, err)
@@ -1868,7 +1869,7 @@ func TestGetLatestForecasts(t *testing.T) {
 			req: &pb.GetLatestForecastsRequest{
 				LocationUuid:      siteResp.LocationUuid,
 				EnergySource:      pb.EnergySource_ENERGY_SOURCE_SOLAR,
-				PivotTimestampUtc: timestamppb.New(pivotTime),
+				PivotTimestampUtc: timestamppb.New(pivotTime.Add(time.Minute)),
 			},
 			expectedInitTimes: []time.Time{
 				pivotTime,

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -1853,7 +1853,9 @@ func TestGetLatestForecasts(t *testing.T) {
 			EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
 			InitTimeUtc:  timestamppb.New(pivotTime.Add(time.Duration(-i) * time.Hour)),
 			Values:       yields,
-			CreatedTimestampUtc: timestamppb.New(pivotTime.Add(time.Duration(-i)*time.Hour + time.Minute)),
+			CreatedTimestampUtc: timestamppb.New(
+				pivotTime.Add(time.Duration(-i)*time.Hour + time.Minute),
+			),
 		}
 		_, err = dc.CreateForecast(t.Context(), req)
 		require.NoError(t, err)

--- a/internal/server/postgres/sql/queries/predictions.sql
+++ b/internal/server/postgres/sql/queries/predictions.sql
@@ -87,7 +87,10 @@ INSERT INTO pred.forecasts (
         '[]'
     ),
     CASE WHEN sqlc.arg(metadata)::JSONB = '{}'::JSONB THEN NULL ELSE sqlc.arg(metadata)::JSONB END,
-    CASE WHEN sqlc.narg(created_at_utc)::TIMESTAMP IS NULL THEN CURRENT_TIMESTAMP ELSE sqlc.narg(created_at_utc)::TIMESTAMP END
+    CASE
+        WHEN sqlc.narg(created_at_utc)::TIMESTAMP IS NULL THEN CURRENT_TIMESTAMP ELSE
+            sqlc.narg(created_at_utc)::TIMESTAMP
+    END
 ) RETURNING
     forecast_uuid,
     init_time_utc,

--- a/internal/server/postgres/sql/queries/predictions.sql
+++ b/internal/server/postgres/sql/queries/predictions.sql
@@ -72,7 +72,8 @@ INSERT INTO pred.forecasts (
     init_time_utc,
     value_resolution_mins,
     target_period,
-    metadata
+    metadata,
+    created_at_utc
 ) VALUES (
     UUIDV7($4::TIMESTAMP),
     $1,
@@ -85,7 +86,8 @@ INSERT INTO pred.forecasts (
         $4::TIMESTAMP + MAKE_INTERVAL(mins => sqlc.arg(last_horizon_mins)::INTEGER),
         '[]'
     ),
-    CASE WHEN sqlc.arg(metadata)::JSONB = '{}'::JSONB THEN NULL ELSE sqlc.arg(metadata)::JSONB END
+    CASE WHEN sqlc.arg(metadata)::JSONB = '{}'::JSONB THEN NULL ELSE sqlc.arg(metadata)::JSONB END,
+    CASE WHEN sqlc.narg(created_at_utc)::TIMESTAMP IS NULL THEN CURRENT_TIMESTAMP ELSE sqlc.narg(created_at_utc)::TIMESTAMP END
 ) RETURNING
     forecast_uuid,
     init_time_utc,
@@ -144,11 +146,11 @@ FROM pred.forecasters AS fr
     CROSS JOIN LATERAL (
         SELECT
             forecast_uuid,
-            init_time_utc,
+            created_at_utc,
             source_type_id,
             geometry_uuid,
             metadata,
-            UUIDV7_EXTRACT_TIMESTAMP(forecast_uuid) AS created_at_utc
+            UUIDV7_EXTRACT_TIMESTAMP(forecast_uuid) AS init_time_utc
         FROM pred.forecasts
         WHERE geometry_uuid = $1
             AND source_type_id = $2
@@ -158,6 +160,7 @@ FROM pred.forecasters AS fr
                     mins => sqlc.arg(horizon_mins)::INTEGER
                 ) + INTERVAL '1 millisecond'
             )
+            AND created_at_utc <= COALESCE(sqlc.narg(pivot_timestamp)::TIMESTAMP, CURRENT_TIMESTAMP)
         ORDER BY forecast_uuid DESC
         LIMIT 1
     ) AS f

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -339,6 +339,14 @@ message CreateForecastRequest {
 
   optional google.protobuf.Struct metadata = 6;
 
+  // The UTC time to set as the created_timestamp for the forecast. Leave empty to use current time.
+  // This is useful for backfilling historical forecasts with accurate created timestamps,
+  // but should generally be left empty for new forecasts.
+  optional google.protobuf.Timestamp created_timestamp_utc = 7 [
+    (buf.validate.field).required = false,
+    (buf.validate.field).timestamp = { gt: { seconds: 112000000}, lt_now: true }
+  ];
+
   //option (buf.validate.message).cel = {
   //  id: "forecast.values.monotonic_horizons"
   //  message: "Forecast horizon values must be monotonically increasing"


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Swaps the init time and the created time in the response of the latest forecasts query such that they are correct.

Closes #155 