### PR TITLE
feat(proto): Add location names filter to ListLocations

### DIFF
--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -1672,6 +1672,7 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 			PermissionID:   permissionId,
 			SourceTypeID:   sourceTypeId,
 			GeometryTypeID: locationTypeId,
+			GeometryNames:  req.LocationNamesFilter,
 		}
 
 		glResp, err := querier.ListSourcesAtTimestamp(ctx, lsprms)

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -1041,8 +1041,18 @@ func TestListLocationsLocationFilters(t *testing.T) {
 			name: "Should filter by location names",
 			req: &pb.ListLocationsRequest{
 				LocationNamesFilter: []string{
-					fmt.Sprintf("test_list_locations_site_%02d_%d_%d", 0, *sourceFilter, *typeFilter),
-					fmt.Sprintf("test_list_locations_site_%02d_%d_%d", 1, *sourceFilter, *typeFilter),
+					fmt.Sprintf(
+						"test_list_locations_site_%02d_%d_%d",
+						0,
+						*sourceFilter,
+						*typeFilter,
+					),
+					fmt.Sprintf(
+						"test_list_locations_site_%02d_%d_%d",
+						1,
+						*sourceFilter,
+						*typeFilter,
+					),
 				},
 			},
 			expectedCount: 2,

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -1038,6 +1038,16 @@ func TestListLocationsLocationFilters(t *testing.T) {
 			expectedCount: 3,
 		},
 		{
+			name: "Should filter by location names",
+			req: &pb.ListLocationsRequest{
+				LocationNamesFilter: []string{
+					fmt.Sprintf("test_list_locations_site_%02d_%d_%d", 0, *sourceFilter, *typeFilter),
+					fmt.Sprintf("test_list_locations_site_%02d_%d_%d", 1, *sourceFilter, *typeFilter),
+				},
+			},
+			expectedCount: 2,
+		},
+		{
 			name: "Should filter by energy source and location type",
 			req: &pb.ListLocationsRequest{
 				EnergySourceFilter:  sourceFilter,

--- a/internal/server/postgres/sql/queries/locations.sql
+++ b/internal/server/postgres/sql/queries/locations.sql
@@ -188,6 +188,10 @@ WHERE
         ARRAY_LENGTH(sqlc.arg(geometry_uuids)::UUID [], 1) IS NULL
         OR us.geometry_uuid = ANY(sqlc.arg(geometry_uuids)::UUID [])
     )
+    AND (
+	ARRAY_LENGTH(sqlc.arg(geometry_names)::TEXT [], 1) IS NULL
+	OR us.geometry_name = ANY(sqlc.arg(geometry_names)::TEXT [])
+    )
     AND (sqlc.narg(geometry_type_id)::SMALLINT IS NULL OR us.geometry_type_id = sqlc.narg(geometry_type_id)::SMALLINT)
     AND (sqlc.narg(oauth_id)::TEXT IS NULL OR us.oauth_id = sqlc.arg(oauth_id)::TEXT)
     AND (sqlc.narg(permission_id)::SMALLINT IS NULL OR us.permission_id = sqlc.narg(permission_id)::SMALLINT);

--- a/internal/server/postgres/sql/queries/locations.sql
+++ b/internal/server/postgres/sql/queries/locations.sql
@@ -189,8 +189,8 @@ WHERE
         OR us.geometry_uuid = ANY(sqlc.arg(geometry_uuids)::UUID [])
     )
     AND (
-	ARRAY_LENGTH(sqlc.arg(geometry_names)::TEXT [], 1) IS NULL
-	OR us.geometry_name = ANY(sqlc.arg(geometry_names)::TEXT [])
+        ARRAY_LENGTH(sqlc.arg(geometry_names)::TEXT [], 1) IS NULL
+        OR us.geometry_name = ANY(sqlc.arg(geometry_names)::TEXT [])
     )
     AND (sqlc.narg(geometry_type_id)::SMALLINT IS NULL OR us.geometry_type_id = sqlc.narg(geometry_type_id)::SMALLINT)
     AND (sqlc.narg(oauth_id)::TEXT IS NULL OR us.oauth_id = sqlc.arg(oauth_id)::TEXT)

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -691,6 +691,14 @@ message ListLocationsRequest {
   optional string enclosed_location_uuid_filter = 7 [
     (buf.validate.field).string.uuid = true
   ];
+  // Optional filter to only return locations with a specific name.
+  repeated string location_names_filter = 8 [
+    (buf.validate.field).repeated.max_items = 100,
+    (buf.validate.field).repeated.items = {
+      string: {min_len: 2, max_len: 100},
+    },
+    (buf.validate.field).repeated.unique = true
+  ];
 
 
   option (buf.validate.message).cel = {
@@ -698,6 +706,12 @@ message ListLocationsRequest {
     message: "enclosing_location_uuid_filter and enclosed_location_uuid_filter cannot both be set"
     expression:
       "!(has(this.enclosing_location_uuid_filter) && has(this.enclosed_location_uuid_filter))"
+  };
+  option (buf.validate.message).cel = {
+  id: "name_uuid_filters_mutually_exclusive"
+  message: "location_names_filter and location_uuids_filter cannot both be set"
+  expression:
+    "!(this.location_names_filter.size() > 0 && this.location_uuids_filter.size() > 0)"
   };
 }
 

--- a/proto/ocf/dp/dp.rules.proto
+++ b/proto/ocf/dp/dp.rules.proto
@@ -37,3 +37,4 @@ extend buf.validate.StringRules {
    expression: "this.size() >= 10" // TODO: Determine proper regex for this
  }];
 }
+


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Adds a filter to the ListLocations route that allows for using the location names directly. Note that this may start to cause problems when the Sites database is merged in, as we may end up with duplicate names. One to think about.

