### PR TITLE
fix(api): Do not error for empty timeseries

### DIFF
--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -1560,24 +1560,19 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 			Int32("dp.forecaster.id", dbExistingForecaster.ForecasterID).
 			Str("dp.time_window", fmt.Sprintf("%s - %s", start.Time.String(), end.Time.String())).
 			Msg("no predictions found")
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No predicted values found for the given location at the given horizon.",
-		)
+	} else {
+		l.Debug().
+			Str("dp.geometry.uuid", dbSource.GeometryUuid.String()).
+			Int16("dp.source.type_id", dbSource.SourceTypeID).
+			Int32("dp.forecaster.id", dbExistingForecaster.ForecasterID).
+			Int32("dp.predictions.count", int32(len(dbValues))).
+			Str("dp.predictions.target_period", fmt.Sprintf(
+				"%s - %s",
+				dbValues[0].TargetTimeUtc.Time.String(),
+				dbValues[len(dbValues)-1].TargetTimeUtc.Time.String(),
+			)).
+			Msg(fmt.Sprintf("found %d predictions", len(dbValues)))
 	}
-
-	l.Debug().
-		Str("dp.geometry.uuid", dbSource.GeometryUuid.String()).
-		Int16("dp.source.type_id", dbSource.SourceTypeID).
-		Int32("dp.forecaster.id", dbExistingForecaster.ForecasterID).
-		Int32("dp.predictions.count", int32(len(dbValues))).
-		Str("dp.predictions.target_period", fmt.Sprintf(
-			"%s - %s",
-			dbValues[0].TargetTimeUtc.Time.String(),
-			dbValues[len(dbValues)-1].TargetTimeUtc.Time.String(),
-		)).
-		Msg("found predictions")
 
 	values := make([]*pb.GetForecastAsTimeseriesResponse_Value, len(dbValues))
 	for i, value := range dbValues {

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -923,7 +923,7 @@ func TestGetForecastAsTimeseries(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "Shouldn't return successfully for horizon 60 mins",
+			name: "Should return no values for horizon 60 mins",
 			req: &pb.GetForecastAsTimeseriesRequest{
 				LocationUuid: siteResp.LocationUuid,
 				Forecaster:   forecasterResp.Forecaster,
@@ -931,7 +931,23 @@ func TestGetForecastAsTimeseries(t *testing.T) {
 				HorizonMins:  60,
 				TimeWindow:   defaultTimeWindow,
 			},
-			expectErr: true,
+			expectedValues: []float32{},
+			expectErr:      false,
+		},
+		{
+			name: "Should return no values for a time window outside of the forecasted values",
+			req: &pb.GetForecastAsTimeseriesRequest{
+				LocationUuid: siteResp.LocationUuid,
+				Forecaster:   forecasterResp.Forecaster,
+				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				HorizonMins:  0,
+				TimeWindow: &pb.TimeWindow{
+					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 48)),
+					EndTimestampUtc:   timestamppb.New(pivotTime.Add(-time.Hour * 42)),
+				},
+			},
+			expectedValues: []float32{},
+			expectErr:      false,
 		},
 		{
 			name: "Should return all predictions for a specific initialization time",


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

In the GetForecastAsTimeseries route, instead of returning an error when no values are returned as has been done previously, now this is accepted as a valid response, and simply an empty list is returned instead.