### PR TITLE
feat(api): Speedier streaming of forecast data

### DIFF
--- a/examples/python-notebook/example.py
+++ b/examples/python-notebook/example.py
@@ -2,12 +2,12 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "dp_sdk",
-# #    "dp_sdk @ ${PROJECT_ROOT}/gen/python", # for local testing
+# #   "dp_sdk @ ${PROJECT_ROOT}/gen/python", # for local testing
 #     "grpclib==0.4.8",
 #     "xarray==2025.7.1",
 # ]
 # [tool.uv.sources]
-# dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.27.0/dp_sdk-0.27.0-py3-none-any.whl" }
+# dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.29.0/dp_sdk-0.29.0-py3-none-any.whl" }
 # ///
 """Example script for pulling data from the data platform.
 
@@ -32,7 +32,7 @@ async def main() -> None:
         dpc = dp.DataPlatformDataServiceStub(channel)
         
         print(":: Getting a UI-style forecast for the UK")
-        print("   This is a composite timeseries that can be made up of values from many different forecasts.")
+        print("\tThis is a composite timeseries that can be made up of values from many different forecasts.")
 
         time_window = dp.TimeWindow(
             start_timestamp_utc=dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=7),
@@ -41,13 +41,22 @@ async def main() -> None:
 
         print(":: -> Getting the UK national location")
         glreq = dp.ListLocationsRequest(
+            location_names_filter=["uk"],
             energy_source_filter=dp.EnergySource.SOLAR,
-            location_type_filter=dp.LocationType.NATION,
         )
         glresp = await dpc.list_locations(glreq)
         print(f":: -> {len(glresp)} available locations")
-        uk_location = next(l for l in glresp.locations if l.location_name == "uk")
+        uk_location = glresp.locations[0]
         print(f"\t{uk_location.effective_capacity_watts=}")
+
+        print(":: -> Getting GSP locations")
+        glreq = dp.ListLocationsRequest(
+            location_type_filter=dp.LocationType.GSP,
+            energy_source_filter=dp.EnergySource.SOLAR,
+        )
+        glresp = await dpc.list_locations(glreq)
+        gsp_locations = glresp.locations
+        print(f"\t{len(gsp_locations)} available GSP locations")
 
         print(":: -> Listing available forecasters called 'blend'")
         lfresp = await dpc.list_forecasters(dp.ListForecastersRequest(latest_versions_only=True))
@@ -106,10 +115,13 @@ async def main() -> None:
 
         print(":: -> Streaming forecast values")
         sdreq = dp.StreamForecastDataRequest(
-            location_uuid=uk_location.location_uuid,
+            location_uuids=[uk_location.location_uuid],
             energy_source=dp.EnergySource.SOLAR,
             forecasters=[f for f in lfresp.forecasters if "blend" in f.forecaster_name][:2],
-            time_window=time_window,
+            time_window=dp.StreamForecastDataRequestTimeWindow(
+                start_timestamp_utc=time_window.start_timestamp_utc,
+                end_timestamp_utc=time_window.end_timestamp_utc,
+            ),
             include_metadata=True,
         )
         forecast_values = []

--- a/internal/interceptors/transaction.go
+++ b/internal/interceptors/transaction.go
@@ -18,7 +18,10 @@ import (
 )
 
 // Establish a private type for the context key to avoid collisions.
-type txKey struct{}
+type (
+	txKey   struct{}
+	poolKey struct{}
+)
 
 // GetTxFromContext retrieves the transaction from the context.
 // It panics if the transaction is not found, as presumably anything calling this function
@@ -33,6 +36,21 @@ func GetTxFromContext(ctx context.Context) pgx.Tx {
 	}
 
 	return tx
+}
+
+// GetPoolFromContext retrieves the connection pool from the context.
+// It panics if the pool is not found, since, as above, anything calling this function
+// expects it to be there, and we shouldn't fail silently in that case.
+func GetPoolFromContext(ctx context.Context) *pgxpool.Pool {
+	pool, ok := ctx.Value(poolKey{}).(*pgxpool.Pool)
+	if !ok {
+		log.Fatal().Msg(
+			"Connection pool not injected to context. Ensure the TransactionInjector interceptor " +
+				"is included in the server's interceptor chain.",
+		)
+	}
+
+	return pool
 }
 
 // transactionInterceptorBuilder defines an interface to inject transactions into the request
@@ -112,6 +130,11 @@ func (ti *transactionInterceptorBuilder) UnaryServerInterceptor(
 }
 
 // StreamServerInterceptor is the gRPC interceptor for handling transactions in streams.
+// For each streaming call, it sets up a transaction from the pool and cleanly rolls back on error.
+// However, it also adds the pool to the context for larger queries. This creates options in its
+// usage, so follow this rule of thumb:
+// - Use the transaction for smaller writes and reads
+// - Use the pool to control the number of connections large queries requiring fan-out.
 func (ti *transactionInterceptorBuilder) StreamServerInterceptor(
 	srv any,
 	ss grpc.ServerStream,
@@ -119,8 +142,12 @@ func (ti *transactionInterceptorBuilder) StreamServerInterceptor(
 	handler grpc.StreamHandler,
 ) error {
 	l := zerolog.Ctx(ss.Context())
+	// Since streaming queries are expected to ask for a lot of data, also add the pool as a whole
+	// to the context, to allow for internal fanning out.
+	poolCtx := context.WithValue(ss.Context(), poolKey{}, ti.pool)
+
 	// Establish a transaction with the database.
-	tx, err := ti.pool.Begin(ss.Context())
+	tx, err := ti.pool.Begin(poolCtx)
 	if err != nil {
 		return status.Error(codes.Internal, "Error communicating with backend")
 	}
@@ -129,14 +156,14 @@ func (ti *transactionInterceptorBuilder) StreamServerInterceptor(
 	defer func() {
 		if err != nil {
 			l.Debug().Msg("rolling back transaction")
-			_ = tx.Rollback(ss.Context())
+			_ = tx.Rollback(poolCtx)
 		} else {
-			_ = tx.Commit(ss.Context())
+			_ = tx.Commit(poolCtx)
 		}
 	}()
 
 	// Create a new context with the transaction injected. Returned errors will trigger the defer.
-	txCtx := context.WithValue(ss.Context(), txKey{}, tx)
+	txCtx := context.WithValue(poolCtx, txKey{}, tx)
 
 	// Wrap the ServerStream to inject our new context.
 	err = handler(srv, &wrappedStream{ServerStream: ss, newCtx: txCtx})

--- a/internal/server/dummy/dataserverimpl.go
+++ b/internal/server/dummy/dataserverimpl.go
@@ -634,29 +634,31 @@ func (d *DataPlatformDataServiceServerImpl) StreamForecastData(
 
 	for _, it := range initializationTimestamps {
 		for _, fc := range req.Forecasters {
-			for _, h := range horizons {
-				tt := it.Add(time.Duration(h) * time.Minute)
-				sd := determineIrradiance(tt, randomUkLngLat())
+			for _, lu := range req.LocationUuids {
+				for _, h := range horizons {
+					tt := it.Add(time.Duration(h) * time.Minute)
+					sd := determineIrradiance(tt, randomUkLngLat())
 
-				err := stream.Send(&pb.StreamForecastDataResponse{
-					InitTimestamp: timestamppb.New(it),
-					LocationUuid:  req.LocationUuid,
-					ForecasterFullname: fmt.Sprintf(
-						"%s:%s",
-						fc.ForecasterName,
-						fc.ForecasterVersion,
-					),
-					HorizonMins: uint32(h),
-					P50Fraction: float32(sd.normalizedIrradiance()),
-					OtherStatisticsFractions: map[string]float32{
-						"p10": float32(sd.normalizedIrradiance()) * 0.95,
-						"p90": float32(sd.normalizedIrradiance()) * 1.05,
-					},
-					CreatedTimestampUtc:    timestamppb.New(time.Now().UTC()),
-					EffectiveCapacityWatts: 150e6,
-				})
-				if err != nil {
-					return err
+					err := stream.Send(&pb.StreamForecastDataResponse{
+						InitTimestamp: timestamppb.New(it),
+						LocationUuid:  lu,
+						ForecasterFullname: fmt.Sprintf(
+							"%s:%s",
+							fc.ForecasterName,
+							fc.ForecasterVersion,
+						),
+						HorizonMins: uint32(h),
+						P50Fraction: float32(sd.normalizedIrradiance()),
+						OtherStatisticsFractions: map[string]float32{
+							"p10": float32(sd.normalizedIrradiance()) * 0.95,
+							"p90": float32(sd.normalizedIrradiance()) * 1.05,
+						},
+						CreatedTimestampUtc:    timestamppb.New(time.Now().UTC()),
+						EffectiveCapacityWatts: 150e6,
+					})
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/internal/server/postgres/bench_test.go
+++ b/internal/server/postgres/bench_test.go
@@ -252,6 +252,45 @@ func BenchmarkPostgresClient(b *testing.B) {
 					require.NoError(b, err)
 				}
 			})
+			b.Run("StreamForecastData", func(b *testing.B) {
+				for b.Loop() {
+					stream, err := dc.StreamForecastData(
+						b.Context(),
+						&pb.StreamForecastDataRequest{
+							LocationUuids: []string{
+								output.LocationUuids[0],
+								output.LocationUuids[1],
+							},
+							EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+							Forecasters: []*pb.Forecaster{{
+								ForecasterName:    tc.NamePrefix + "_forecaster_1",
+								ForecasterVersion: "v1",
+							}},
+							TimeWindow: &pb.StreamForecastDataRequest_TimeWindow{
+								StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 48)),
+								EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 36)),
+							},
+						},
+					)
+					require.NoError(b, err)
+
+					var numValues int
+					for {
+						_, err := stream.Recv()
+						if err != nil {
+							break
+						}
+
+						numValues++
+					}
+
+					require.GreaterOrEqual(
+						b,
+						numValues,
+						(48+12)*60/30,
+					)
+				}
+			})
 		})
 	}
 }

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -474,14 +475,7 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 	stream grpc.ServerStreamingServer[pb.StreamForecastDataResponse],
 ) error {
 	l := zerolog.Ctx(stream.Context())
-
-	tx := ix.GetTxFromContext(stream.Context())
-
-	locationUuid, err := uuid.Parse(req.LocationUuid)
-	if err != nil {
-		l.Err(err).Msgf("uuid.Parse(%s)", req.LocationUuid)
-		return status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
-	}
+	pool := ix.GetPoolFromContext(stream.Context())
 
 	var (
 		fNames    []string
@@ -493,93 +487,125 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 		fVersions = append(fVersions, fc.ForecasterVersion)
 	}
 
-	// Query with the transaction directly so the returned data can be streamed.
-	// This is to avoid very large data requests choking the memory of the API.
-	// Normally I woudn't want to bypass SQLC's type safety - but this RPC is specifically for
-	// ML debugging and isn't on any hot path, so I don't mind here.
-	rows, err := tx.Query(
-		stream.Context(),
-		db.ListPredictionsForForecasts,
-		int16(req.EnergySource.Number()),
-		fNames,
-		fVersions,
-		locationUuid,
-		pgtype.Timestamp{
-			Time:  req.TimeWindow.StartTimestampUtc.AsTime(),
-			Valid: true,
-		},
-		pgtype.Timestamp{
-			Time:  req.TimeWindow.EndTimestampUtc.AsTime(),
-			Valid: true,
-		},
-	)
-	if err != nil {
-		l.Err(err).Msg("tx.Query(ListPredictionsForForecasts) failed")
-		return status.Errorf(codes.Internal, "Failed to stream predictions")
-	}
-	defer rows.Close()
+	// Instantiate a worker pool of a limited size to handle the query.
+	eg, ctx := errgroup.WithContext(stream.Context())
+	eg.SetLimit(2)
+	resChan := make(chan *pb.StreamForecastDataResponse, 1000)
 
-	for rows.Next() {
-		var row db.ListPredictionsForForecastsRow
-
-		err := rows.Scan(
-			&row.InitTimeUtc,
-			&row.ForecasterName,
-			&row.ForecasterVersion,
-			&row.CreatedAtUtc,
-			&row.HorizonMins,
-			&row.P50Sip,
-			&row.OtherStatsFractions,
-			&row.CapacityWatts,
-			&row.Metadata,
-		)
-		if err != nil {
-			l.Err(err).Msg("rows.Scan failed")
-			return status.Errorf(codes.Internal, "Error reading prediction stream")
-		}
-
-		otherStatistics := make(map[string]float32)
-		if row.OtherStatsFractions != nil {
-			for k, v := range row.OtherStatsFractions.AsMap() {
-				otherStatistics[k] = float32(v.(float64))
+	// Fan out queries for each location to the database.
+	for _, locStr := range req.LocationUuids {
+		eg.Go(func() error {
+			locationUuid, err := uuid.Parse(locStr)
+			if err != nil {
+				l.Err(err).Msgf("uuid.Parse(%s)", locStr)
+				return status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
 			}
-		}
 
-		metadata := make(map[string]string)
-		if req.IncludeMetadata && row.Metadata != nil {
-			for k, v := range row.Metadata.AsMap() {
-				metadata[k] = v.(string)
+			// Query with the pool directly so each concurrent request gets a fresh connection.
+			// This is to avoid very large data requests choking the memory of the API.
+			// Normally I woudn't want to bypass SQLC's type safety - but this RPC is specifically for
+			// ML debugging and isn't on any hot path, so I don't mind here.
+			rows, err := pool.Query(
+				stream.Context(),
+				db.ListPredictionsForForecasts,
+				pgtype.Timestamp{
+					Time:  req.TimeWindow.StartTimestampUtc.AsTime(),
+					Valid: true,
+				},
+				pgtype.Timestamp{
+					Time:  req.TimeWindow.EndTimestampUtc.AsTime(),
+					Valid: true,
+				},
+				locationUuid,
+				int16(req.EnergySource.Number()),
+				fNames,
+				fVersions,
+			)
+			if err != nil {
+				l.Err(err).Msg("tx.Query(ListPredictionsForForecasts) failed")
+				return status.Errorf(codes.Internal, "Failed to stream predictions")
 			}
-		}
+			defer rows.Close()
 
-		err = stream.Send(&pb.StreamForecastDataResponse{
-			InitTimestamp: timestamppb.New(row.InitTimeUtc.Time),
-			LocationUuid:  req.LocationUuid,
-			ForecasterFullname: fmt.Sprintf(
-				"%s:%s",
-				row.ForecasterName,
-				row.ForecasterVersion,
-			),
-			HorizonMins:              uint32(row.HorizonMins),
-			P50Fraction:              float32(row.P50Sip) / 30000.0,
-			OtherStatisticsFractions: otherStatistics,
-			CreatedTimestampUtc:      timestamppb.New(row.CreatedAtUtc.Time),
-			EffectiveCapacityWatts:   uint64(row.CapacityWatts),
-			Metadata:                 metadata,
+			for rows.Next() {
+				var row db.ListPredictionsForForecastsRow
+
+				err := rows.Scan(
+					&row.InitTimeUtc,
+					&row.ForecasterName,
+					&row.ForecasterVersion,
+					&row.CreatedAtUtc,
+					&row.HorizonMins,
+					&row.P50Sip,
+					&row.OtherStatsFractions,
+					&row.CapacityWatts,
+					&row.Metadata,
+				)
+				if err != nil {
+					l.Err(err).Msg("rows.Scan failed")
+					return status.Errorf(codes.Internal, "Error reading prediction stream")
+				}
+
+				otherStatistics := make(map[string]float32)
+				if row.OtherStatsFractions != nil {
+					for k, v := range row.OtherStatsFractions.AsMap() {
+						otherStatistics[k] = float32(v.(float64))
+					}
+				}
+
+				metadata := make(map[string]string)
+				if req.IncludeMetadata && row.Metadata != nil {
+					for k, v := range row.Metadata.AsMap() {
+						metadata[k] = v.(string)
+					}
+				}
+
+				res := &pb.StreamForecastDataResponse{
+					InitTimestamp: timestamppb.New(row.InitTimeUtc.Time),
+					LocationUuid:  locationUuid.String(),
+					ForecasterFullname: fmt.Sprintf(
+						"%s:%s",
+						row.ForecasterName,
+						row.ForecasterVersion,
+					),
+					HorizonMins:              uint32(row.HorizonMins),
+					P50Fraction:              float32(row.P50Sip) / 30000.0,
+					OtherStatisticsFractions: otherStatistics,
+					CreatedTimestampUtc:      timestamppb.New(row.CreatedAtUtc.Time),
+					EffectiveCapacityWatts:   uint64(row.CapacityWatts),
+					Metadata:                 metadata,
+				}
+				select {
+				case resChan <- res:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			l.Debug().
+				Str("dp.geometry.uuid", locationUuid.String()).
+				Msg("streamed forecasts for location")
+
+			return rows.Err()
 		})
-		// If the client disconnects or network fails, break the loop
+	}
+
+	// Wait for all DB workers to finish before closing the channel to signal the streamer to finish.
+	go func() {
+		_ = eg.Wait()
+
+		close(resChan)
+	}()
+
+	// Consume the channel and stream to the client as results come in.
+	// If the client disconnects, the context is cancelled, which terminates the workers.
+	for res := range resChan {
+		err := stream.Send(res)
 		if err != nil {
-			l.Warn().Err(err).Msg("Client stream closed prematurely")
 			return err
 		}
 	}
 
-	if err := rows.Err(); err != nil {
-		l.Err(err).Msg("rows.Err() reported a streaming failure")
-		return status.Errorf(codes.Internal, "Stream interrupted")
-	}
-
-	return nil
+	return eg.Wait()
 }
 
 func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -581,6 +581,7 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 					return ctx.Err()
 				}
 			}
+
 			l.Debug().
 				Str("dp.geometry.uuid", locationUuid.String()).
 				Msg("streamed forecasts for location")

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -2058,7 +2058,7 @@ func TestStreamForecastData(t *testing.T) {
 		{
 			name: "Should successfully stream forecasts for a single forecaster",
 			req: &pb.StreamForecastDataRequest{
-				LocationUuid:    siteResp.LocationUuid,
+				LocationUuids:   []string{siteResp.LocationUuid},
 				EnergySource:    pb.EnergySource_ENERGY_SOURCE_SOLAR,
 				Forecasters:     []*pb.Forecaster{fc1Resp.Forecaster},
 				TimeWindow:      defaultTimeWindow,
@@ -2071,7 +2071,7 @@ func TestStreamForecastData(t *testing.T) {
 		{
 			name: "Should successfully stream forecasts for multiple forecasters",
 			req: &pb.StreamForecastDataRequest{
-				LocationUuid:    siteResp.LocationUuid,
+				LocationUuids:   []string{siteResp.LocationUuid},
 				EnergySource:    pb.EnergySource_ENERGY_SOURCE_SOLAR,
 				Forecasters:     []*pb.Forecaster{fc1Resp.Forecaster, fc2Resp.Forecaster},
 				TimeWindow:      defaultTimeWindow,
@@ -2084,9 +2084,9 @@ func TestStreamForecastData(t *testing.T) {
 		{
 			name: "Should only return forecasts whos init times respect the time window boundaries",
 			req: &pb.StreamForecastDataRequest{
-				LocationUuid: siteResp.LocationUuid,
-				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
-				Forecasters:  []*pb.Forecaster{fc1Resp.Forecaster},
+				LocationUuids: []string{siteResp.LocationUuid},
+				EnergySource:  pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				Forecasters:   []*pb.Forecaster{fc1Resp.Forecaster},
 				TimeWindow: &pb.StreamForecastDataRequest_TimeWindow{
 					// Constrain the window to only capture the most recent forecast
 					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Minute * 10)),
@@ -2100,7 +2100,7 @@ func TestStreamForecastData(t *testing.T) {
 		{
 			name: "Should include metadata when asked",
 			req: &pb.StreamForecastDataRequest{
-				LocationUuid:    siteResp.LocationUuid,
+				LocationUuids:   []string{siteResp.LocationUuid},
 				EnergySource:    pb.EnergySource_ENERGY_SOURCE_SOLAR,
 				Forecasters:     []*pb.Forecaster{fc1Resp.Forecaster},
 				TimeWindow:      defaultTimeWindow,
@@ -2113,10 +2113,10 @@ func TestStreamForecastData(t *testing.T) {
 		{
 			name: "Should fail gracefully with an invalid UUID",
 			req: &pb.StreamForecastDataRequest{
-				LocationUuid: "not-a-valid-uuid",
-				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
-				Forecasters:  []*pb.Forecaster{fc1Resp.Forecaster},
-				TimeWindow:   defaultTimeWindow,
+				LocationUuids: []string{"not-a-valid-uuid"},
+				EnergySource:  pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				Forecasters:   []*pb.Forecaster{fc1Resp.Forecaster},
+				TimeWindow:    defaultTimeWindow,
 			},
 			expectErr: true,
 		},

--- a/internal/server/postgres/sql/migrations/00006_sources_mv_index.sql
+++ b/internal/server/postgres/sql/migrations/00006_sources_mv_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+-- Replace the old materialized view index for one suited to location-specific lookups
+DROP INDEX IF EXISTS sources_mv_sys_period_idx;
+CREATE INDEX idx_sources_mv_composite_gist ON loc.sources_mv USING gist (geometry_uuid, source_type_id, sys_period);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_sources_mv_composite_gist;
+CREATE INDEX sources_mv_sys_period_idx ON loc.sources_mv USING gist (sys_period);

--- a/internal/server/postgres/sql/queries/predictions.sql
+++ b/internal/server/postgres/sql/queries/predictions.sql
@@ -131,6 +131,7 @@ INSERT INTO pred.predicted_generation_values (
 -- name: ListPredictionsForForecasts :many
 /* ListPredictionsForForecasts retrieves all predicted generation values for a given location,
  * source type, and dynamic list of forecasters within a time window.
+ * Note that this does not return ordered results for speed. Ordering is up to the client.
  */
 WITH requested_forecasters AS (
     SELECT
@@ -146,40 +147,35 @@ matched_forecasters AS (
         INNER JOIN requested_forecasters AS rf
         ON f.forecaster_name = LOWER(rf.fname)
             AND f.forecaster_version = LOWER(rf.fversion)
-),
-target_forecasts AS (
-    SELECT
-        f.forecast_uuid,
-        f.created_at_utc,
-        f.geometry_uuid,
-        f.metadata AS forecast_metadata,
-        mf.forecaster_name,
-        mf.forecaster_version,
-        UUIDV7_EXTRACT_TIMESTAMP(f.forecast_uuid)::TIMESTAMP AS init_time_utc
-    FROM pred.forecasts AS f
-        INNER JOIN matched_forecasters AS mf USING (forecaster_id)
-    WHERE f.geometry_uuid = sqlc.arg(geometry_uuid)::UUID
-        AND f.source_type_id = sqlc.arg(source_type_id)::SMALLINT
-        AND f.forecast_uuid >= UUIDV7_BOUNDARY(sqlc.arg(start_timestamp)::TIMESTAMP)
-        AND f.forecast_uuid < UUIDV7_BOUNDARY(sqlc.arg(end_timestamp)::TIMESTAMP + INTERVAL '1 millisecond')
 )
 SELECT
-    tf.init_time_utc,
-    tf.forecaster_name,
-    tf.forecaster_version,
-    tf.created_at_utc,
+    UUIDV7_EXTRACT_TIMESTAMP(f.forecast_uuid)::TIMESTAMP AS init_time_utc,
+    mf.forecaster_name,
+    mf.forecaster_version,
+    f.created_at_utc,
     pg.horizon_mins,
     pg.p50_sip,
     pg.other_stats_fractions,
     sv.capacity_watts,
-    COALESCE(pg.metadata || tf.forecast_metadata, pg.metadata, tf.forecast_metadata) AS metadata
-FROM target_forecasts AS tf
-    INNER JOIN pred.predicted_generation_values AS pg USING (forecast_uuid)
-    INNER JOIN loc.sources_mv AS sv
-    ON tf.geometry_uuid = sv.geometry_uuid
-        AND sv.source_type_id = sqlc.arg(source_type_id)::SMALLINT
-WHERE sv.sys_period @> pg.target_time_utc
-ORDER BY tf.init_time_utc ASC, pg.horizon_mins ASC;
+    COALESCE(pg.metadata || f.metadata, pg.metadata, f.metadata) AS metadata
+FROM pred.forecasts AS f
+    INNER JOIN matched_forecasters AS mf USING (forecaster_id)
+    INNER JOIN pred.predicted_generation_values AS pg
+    ON f.forecast_uuid = pg.forecast_uuid
+        AND pg.forecast_uuid >= UUIDV7_BOUNDARY(sqlc.arg(start_timestamp)::TIMESTAMP)
+        AND pg.forecast_uuid < UUIDV7_BOUNDARY(sqlc.arg(end_timestamp)::TIMESTAMP + INTERVAL '1 millisecond')
+    LEFT OUTER JOIN LATERAL (
+        SELECT capacity_watts
+        FROM loc.sources_mv AS s
+        WHERE s.geometry_uuid = f.geometry_uuid
+            AND s.source_type_id = f.source_type_id
+            AND s.sys_period @> pg.target_time_utc
+        LIMIT 1
+    ) AS sv ON TRUE
+WHERE f.geometry_uuid = sqlc.arg(geometry_uuid)::UUID
+    AND f.source_type_id = sqlc.arg(source_type_id)::SMALLINT
+    AND f.forecast_uuid >= UUIDV7_BOUNDARY(sqlc.arg(start_timestamp)::TIMESTAMP)
+    AND f.forecast_uuid < UUIDV7_BOUNDARY(sqlc.arg(end_timestamp)::TIMESTAMP + INTERVAL '1 millisecond');
 
 -- name: GetLatestForecastsAtHorizonSincePivot :many
 /* GetLatestForecastAtHorizonSincePivot retrieves the latest forecasts for a given location

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -711,7 +711,7 @@ message ListLocationsRequest {
   repeated string location_names_filter = 8 [
     (buf.validate.field).repeated.max_items = 100,
     (buf.validate.field).repeated.items = {
-      string: {min_len: 2, max_len: 100},
+      string: {min_len: 2, max_len: 500},
     },
     (buf.validate.field).repeated.unique = true
   ];
@@ -775,9 +775,13 @@ message StreamForecastDataRequest {
     };
   }
 
-  string location_uuid = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).string.uuid = true
+  repeated string location_uuids = 1 [
+    (buf.validate.field).repeated.min_items = 1,
+    (buf.validate.field).repeated.max_items = 1000,
+    (buf.validate.field).repeated.unique = true,
+    (buf.validate.field).repeated.items = {
+      string: {uuid: true}
+    }
   ];
   EnergySource energy_source = 2 [
     (buf.validate.field).required = true 


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Modifies the index on the sources materialized view, and updates the underlying sql of the StreamForecastData implementation. Also modifues the schema to take a list of location uuids, and uses the connection pool directly, to enable controllable parallelisation of the query in-api, as opposed to by-client.
