### PR TITLE
feat(api): Batch StreamForecastData responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ build-backend = "setuptools.build_meta"
 name = "dp-sdk"
 dynamic = ["version"]
 description = "Python client for OCF Data Platform API"
-dependencies = ["betterproto==2.0.0b7", "grpcio"]
+dependencies = ["betterproto==2.0.0b7", "grpcio==1.80.0", "protobuf==7.34.1"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,6 +99,8 @@ func main() {
 				grpc.StreamServerInterceptor(logInterceptor.StreamServerInterceptor),
 				grpc.StreamServerInterceptor(txInterceptor.StreamServerInterceptor),
 			),
+			grpc.InitialWindowSize(1<<20),
+			grpc.InitialConnWindowSize(2<<20),
 		)
 	} else {
 		log.Fatal().Str("url", databaseUrl).Msg("unsupported DATABASE_URL format")

--- a/examples/python-notebook/example.py
+++ b/examples/python-notebook/example.py
@@ -7,17 +7,18 @@
 #     "xarray==2025.7.1",
 # ]
 # [tool.uv.sources]
-# dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.29.0/dp_sdk-0.29.0-py3-none-any.whl" }
+# dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.30.0/dp_sdk-0.30.0-py3-none-any.whl" }
 # ///
 """Example script for pulling data from the data platform.
 
 Run with `$ uv run example.py`
 """
 
-from grpclib.client import Channel
-import betterproto
 import asyncio
-from ocf import dp
+import grpc.aio
+from google.protobuf.json_format import MessageToDict
+from ocf.dp.dp import common_pb2
+from ocf.dp.dp_data import messages_pb2, service_pb2_grpc
 import pandas as pd
 import xarray as xr
 import datetime as dt
@@ -28,59 +29,62 @@ async def main() -> None:
     try:
         print(":: Creating a client")
         # Ensure you have a connection to a data platform instance on port 50051 before starting the script
-        channel = Channel(host="localhost", port=50051)
-        dpc = dp.DataPlatformDataServiceStub(channel)
+        channel = grpc.aio.insecure_channel("localhost:50051")
+        dpc = service_pb2_grpc.DataPlatformDataServiceStub(channel)
         
         print(":: Getting a UI-style forecast for the UK")
         print("\tThis is a composite timeseries that can be made up of values from many different forecasts.")
 
-        time_window = dp.TimeWindow(
+        time_window = messages_pb2.TimeWindow(
             start_timestamp_utc=dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=7),
             end_timestamp_utc=dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=5),
         )
 
         print(":: -> Getting the UK national location")
-        glreq = dp.ListLocationsRequest(
+        glreq = messages_pb2.ListLocationsRequest(
             location_names_filter=["uk"],
-            energy_source_filter=dp.EnergySource.SOLAR,
+            energy_source_filter=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
         )
-        glresp = await dpc.list_locations(glreq)
-        print(f":: -> {len(glresp)} available locations")
+        glresp = await dpc.ListLocations(glreq)
+        print(f":: -> {len(glresp.locations)} available locations")
         uk_location = glresp.locations[0]
         print(f"\t{uk_location.effective_capacity_watts=}")
 
         print(":: -> Getting GSP locations")
-        glreq = dp.ListLocationsRequest(
-            location_type_filter=dp.LocationType.GSP,
-            energy_source_filter=dp.EnergySource.SOLAR,
+        glreq = messages_pb2.ListLocationsRequest(
+            location_type_filter=common_pb2.LocationType.LOCATION_TYPE_GSP,
+            energy_source_filter=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
         )
-        glresp = await dpc.list_locations(glreq)
+        glresp = await dpc.ListLocations(glreq)
         gsp_locations = glresp.locations
         print(f"\t{len(gsp_locations)} available GSP locations")
 
         print(":: -> Listing available forecasters called 'blend'")
-        lfresp = await dpc.list_forecasters(dp.ListForecastersRequest(latest_versions_only=True))
+        lfresp = await dpc.ListForecasters(messages_pb2.ListForecastersRequest(latest_versions_only=True))
         blend_forecaster = next(f for f in lfresp.forecasters if "blend" in f.forecaster_name)
         print(f"\t{blend_forecaster}")
 
         print(":: -> Getting a forecast for the UK national location")
-        gfreq = dp.GetForecastAsTimeseriesRequest(
+        gfreq = messages_pb2.GetForecastAsTimeseriesRequest(
             location_uuid=uk_location.location_uuid,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
             forecaster=blend_forecaster,
             time_window=time_window,
             horizon_mins=0,
         )
-        gfreq_response = await dpc.get_forecast_as_timeseries(gfreq)
-        start_time = gfreq_response.values[0].target_timestamp_utc
-        end_time = gfreq_response.values[-1].target_timestamp_utc
+        gfreq_response = await dpc.GetForecastAsTimeseries(gfreq)
+        start_time = gfreq_response.values[0].target_timestamp_utc.ToDatetime(tzinfo=dt.UTC)
+        end_time = gfreq_response.values[-1].target_timestamp_utc.ToDatetime(tzinfo=dt.UTC)
         print(f"\tReceived {len(gfreq_response.values)} forecast points from {start_time} to {end_time}")
 
         print(f":: -> Converting response to a dataframe")
+        # preserving_proto_field_name prevents conversion to lowerCamelCase.
+        # always_print_fields_with_no_presence ensures all fields are present in the dict, even if they have no value in the protobuf.
         df = pd.DataFrame.from_dict([
-            v.to_dict(include_default_values=True, casing=betterproto.Casing.SNAKE)
+            MessageToDict(v, always_print_fields_with_no_presence=True, preserving_proto_field_name=True)
             for v in gfreq_response.values
-        ]).pipe(
+        ])
+        df = df.pipe(
             lambda df: df.join(pd.json_normalize(df['other_statistics_fractions']))
         ).drop("other_statistics_fractions", axis=1).set_index(
             "target_timestamp_utc"
@@ -94,44 +98,44 @@ async def main() -> None:
         print(f":: Getting 'ground truths' for the same location and time period")
 
         print(f":: -> Getting an observer")
-        loresp = await dpc.list_observers(dp.ListObserversRequest())
+        loresp = await dpc.ListObservers(messages_pb2.ListObserversRequest())
         observer = next(o for o in loresp.observers if "pvlive" in o.observer_name)
         print(f"\t{observer.observer_name=}")
 
         print(f":: -> Getting the ground truth for the UK national location")
-        gtreq = dp.GetObservationsAsTimeseriesRequest(
+        gtreq = messages_pb2.GetObservationsAsTimeseriesRequest(
             location_uuid=uk_location.location_uuid,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
             observer_name=observer.observer_name,
             time_window=time_window,
         )
-        gtresp = await dpc.get_observations_as_timeseries(gtreq)
-        start_time = gtresp.values[0].timestamp_utc
-        end_time = gtresp.values[-1].timestamp_utc
+        gtresp = await dpc.GetObservationsAsTimeseries(gtreq)
+        start_time = gtresp.values[0].timestamp_utc.ToDatetime(tzinfo=dt.UTC)
+        end_time = gtresp.values[-1].timestamp_utc.ToDatetime(tzinfo=dt.UTC)
         print(f"\tReceived {len(gtresp.values)} ground truth points from {start_time} to {end_time}")
 
         print(":: Getting ALL forecasts for a given location for multiple forecasters and time periods")
         print("   These forecasts are not composite, so will overlap in time.")
 
         print(":: -> Streaming forecast values")
-        sdreq = dp.StreamForecastDataRequest(
+        sdreq = messages_pb2.StreamForecastDataRequest(
             location_uuids=[uk_location.location_uuid],
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
             forecasters=[f for f in lfresp.forecasters if "blend" in f.forecaster_name][:2],
-            time_window=dp.StreamForecastDataRequestTimeWindow(
+            time_window=messages_pb2.StreamForecastDataRequest.TimeWindow(
                 start_timestamp_utc=time_window.start_timestamp_utc,
                 end_timestamp_utc=time_window.end_timestamp_utc,
             ),
             include_metadata=True,
         )
         forecast_values = []
-        async for chunk in dpc.stream_forecast_data(sdreq):
-            forecast_values.append(chunk)
+        async for chunk in dpc.StreamForecastData(sdreq):
+            forecast_values.extend(chunk.values)
         print(f"\tReceived {len(forecast_values)} forecast points for {len(sdreq.forecasters)} forecasters")
 
         print(":: -> Converting values to a dataframe")
         df = pd.DataFrame.from_dict([
-            f.to_dict(include_default_values=True, casing=betterproto.Casing.SNAKE)
+            MessageToDict(f, always_print_fields_with_no_presence=True, preserving_proto_field_name=True)
             for f in forecast_values
         ]).pipe(
             lambda df: df.join(pd.json_normalize(df['other_statistics_fractions']))
@@ -141,12 +145,12 @@ async def main() -> None:
         print(df.head())
 
         print(":: That's it!")
-        print("   Remeber: When using betterproto's `to_dict()` function,") 
-        print("    ALWAYS set `include_default_values=True`")
+        print("   Remeber: When using protobuf's `MessageToDict()` function,") 
+        print("    ALWAYS set `always_print_fields_with_no_presence=True`")
 
 
     finally:
-        channel.close()
+        await channel.close()
 
 
 if __name__ == "__main__":

--- a/internal/interceptors/transaction.go
+++ b/internal/interceptors/transaction.go
@@ -130,43 +130,23 @@ func (ti *transactionInterceptorBuilder) UnaryServerInterceptor(
 }
 
 // StreamServerInterceptor is the gRPC interceptor for handling transactions in streams.
-// For each streaming call, it sets up a transaction from the pool and cleanly rolls back on error.
-// However, it also adds the pool to the context for larger queries. This creates options in its
-// usage, so follow this rule of thumb:
-// - Use the transaction for smaller writes and reads
-// - Use the pool to control the number of connections large queries requiring fan-out.
+// This does not automatically manage transactions like the unary interceptor, since server-streaming
+// RPCs are expected to be longer-lived, read only, and require concurrency. Instead, it adds the
+// connection pool as-is to the context. Errors and transactions must be handled by the
+// implementations, since opening a transaction for the stream here might result in long-lived
+// transactions, which prevent vacuuming.
 func (ti *transactionInterceptorBuilder) StreamServerInterceptor(
 	srv any,
 	ss grpc.ServerStream,
 	info *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,
 ) error {
-	l := zerolog.Ctx(ss.Context())
-	// Since streaming queries are expected to ask for a lot of data, also add the pool as a whole
+	// Since streaming queries are expected to ask for a lot of data, add the pool as a whole
 	// to the context, to allow for internal fanning out.
 	poolCtx := context.WithValue(ss.Context(), poolKey{}, ti.pool)
 
-	// Establish a transaction with the database.
-	tx, err := ti.pool.Begin(poolCtx)
-	if err != nil {
-		return status.Error(codes.Internal, "Error communicating with backend")
-	}
-
-	// If an error occurred, rollback the transaction.
-	defer func() {
-		if err != nil {
-			l.Debug().Msg("rolling back transaction")
-			_ = tx.Rollback(poolCtx)
-		} else {
-			_ = tx.Commit(poolCtx)
-		}
-	}()
-
-	// Create a new context with the transaction injected. Returned errors will trigger the defer.
-	txCtx := context.WithValue(poolCtx, txKey{}, tx)
-
 	// Wrap the ServerStream to inject our new context.
-	err = handler(srv, &wrappedStream{ServerStream: ss, newCtx: txCtx})
+	err := handler(srv, &wrappedStream{ServerStream: ss, newCtx: poolCtx})
 	if err != nil {
 		return err
 	}

--- a/internal/server/dummy/dataserverimpl.go
+++ b/internal/server/dummy/dataserverimpl.go
@@ -632,6 +632,9 @@ func (d *DataPlatformDataServiceServerImpl) StreamForecastData(
 		horizons[i] = 30 * i
 	}
 
+	const batchSize = 1000
+	batch := make([]*pb.ForecastDatum, 0, batchSize)
+
 	for _, it := range initializationTimestamps {
 		for _, fc := range req.Forecasters {
 			for _, lu := range req.LocationUuids {
@@ -639,7 +642,7 @@ func (d *DataPlatformDataServiceServerImpl) StreamForecastData(
 					tt := it.Add(time.Duration(h) * time.Minute)
 					sd := determineIrradiance(tt, randomUkLngLat())
 
-					err := stream.Send(&pb.StreamForecastDataResponse{
+					batch = append(batch, &pb.ForecastDatum{
 						InitTimestamp: timestamppb.New(it),
 						LocationUuid:  lu,
 						ForecasterFullname: fmt.Sprintf(
@@ -656,11 +659,24 @@ func (d *DataPlatformDataServiceServerImpl) StreamForecastData(
 						CreatedTimestampUtc:    timestamppb.New(time.Now().UTC()),
 						EffectiveCapacityWatts: 150e6,
 					})
-					if err != nil {
-						return err
+
+					if len(batch) >= batchSize {
+						err := stream.Send(&pb.StreamForecastDataResponse{Values: batch})
+						if err != nil {
+							return err
+						}
+
+						batch = make([]*pb.ForecastDatum, 0, batchSize)
 					}
 				}
 			}
+		}
+	}
+
+	if len(batch) > 0 {
+		err := stream.Send(&pb.StreamForecastDataResponse{Values: batch})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/server/postgres/bench_test.go
+++ b/internal/server/postgres/bench_test.go
@@ -276,12 +276,11 @@ func BenchmarkPostgresClient(b *testing.B) {
 
 					var numValues int
 					for {
-						_, err := stream.Recv()
+						resp, err := stream.Recv()
 						if err != nil {
 							break
 						}
-
-						numValues++
+						numValues += len(resp.Values)
 					}
 
 					require.GreaterOrEqual(

--- a/internal/server/postgres/bench_test.go
+++ b/internal/server/postgres/bench_test.go
@@ -280,6 +280,7 @@ func BenchmarkPostgresClient(b *testing.B) {
 						if err != nil {
 							break
 						}
+
 						numValues += len(resp.Values)
 					}
 

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -482,116 +482,144 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 		fVersions []string
 	)
 
+	const batchSize = 200
+
 	for _, fc := range req.Forecasters {
 		fNames = append(fNames, fc.ForecasterName)
 		fVersions = append(fVersions, fc.ForecasterVersion)
 	}
 
 	// Instantiate a worker pool of a limited size to handle the query.
+	// Handy blog on errgroups: https://oneuptime.com/blog/post/2026-01-07-go-errgroup
 	eg, ctx := errgroup.WithContext(stream.Context())
-	eg.SetLimit(2)
-	resChan := make(chan *pb.StreamForecastDataResponse, 1000)
+	eg.SetLimit(int(pool.Config().MaxConns) - 1)
+	resChan := make(chan *pb.StreamForecastDataResponse, 100)
 
 	// Fan out queries for each location to the database.
-	for _, locStr := range req.LocationUuids {
-		eg.Go(func() error {
-			locationUuid, err := uuid.Parse(locStr)
-			if err != nil {
-				l.Err(err).Msgf("uuid.Parse(%s)", locStr)
-				return status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
-			}
-
-			// Query with the pool directly so each concurrent request gets a fresh connection.
-			// This is to avoid very large data requests choking the memory of the API.
-			// Normally I woudn't want to bypass SQLC's type safety - but this RPC is specifically for
-			// ML debugging and isn't on any hot path, so I don't mind here.
-			rows, err := pool.Query(
-				stream.Context(),
-				db.ListPredictionsForForecasts,
-				pgtype.Timestamp{
-					Time:  req.TimeWindow.StartTimestampUtc.AsTime(),
-					Valid: true,
-				},
-				pgtype.Timestamp{
-					Time:  req.TimeWindow.EndTimestampUtc.AsTime(),
-					Valid: true,
-				},
-				locationUuid,
-				int16(req.EnergySource.Number()),
-				fNames,
-				fVersions,
-			)
-			if err != nil {
-				l.Err(err).Msg("tx.Query(ListPredictionsForForecasts) failed")
-				return status.Errorf(codes.Internal, "Failed to stream predictions")
-			}
-			defer rows.Close()
-
-			for rows.Next() {
-				var row db.ListPredictionsForForecastsRow
-
-				err := rows.Scan(
-					&row.InitTimeUtc,
-					&row.ForecasterName,
-					&row.ForecasterVersion,
-					&row.CreatedAtUtc,
-					&row.HorizonMins,
-					&row.P50Sip,
-					&row.OtherStatsFractions,
-					&row.CapacityWatts,
-					&row.Metadata,
-				)
-				if err != nil {
-					l.Err(err).Msg("rows.Scan failed")
-					return status.Errorf(codes.Internal, "Error reading prediction stream")
-				}
-
-				otherStatistics := make(map[string]float32)
-				if row.OtherStatsFractions != nil {
-					for k, v := range row.OtherStatsFractions.AsMap() {
-						otherStatistics[k] = float32(v.(float64))
-					}
-				}
-
-				metadata := make(map[string]string)
-				if req.IncludeMetadata && row.Metadata != nil {
-					for k, v := range row.Metadata.AsMap() {
-						metadata[k] = v.(string)
-					}
-				}
-
-				res := &pb.StreamForecastDataResponse{
-					InitTimestamp: timestamppb.New(row.InitTimeUtc.Time),
-					LocationUuid:  locationUuid.String(),
-					ForecasterFullname: fmt.Sprintf(
-						"%s:%s",
-						row.ForecasterName,
-						row.ForecasterVersion,
-					),
-					HorizonMins:              uint32(row.HorizonMins),
-					P50Fraction:              float32(row.P50Sip) / 30000.0,
-					OtherStatisticsFractions: otherStatistics,
-					CreatedTimestampUtc:      timestamppb.New(row.CreatedAtUtc.Time),
-					EffectiveCapacityWatts:   uint64(row.CapacityWatts),
-					Metadata:                 metadata,
-				}
-				select {
-				case resChan <- res:
-				case <-ctx.Done():
+	go func() {
+		for _, locStr := range req.LocationUuids {
+			eg.Go(func() error {
+				// Check for errors prior to running query.
+				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-			}
 
-			l.Debug().
-				Str("dp.geometry.uuid", locationUuid.String()).
-				Msg("streamed forecasts for location")
+				l.Debug().Str("loc", locStr).Msg("STARTING database query")
 
-			return rows.Err()
-		})
-	}
+				locationUuid, err := uuid.Parse(locStr)
+				if err != nil {
+					l.Err(err).Msgf("uuid.Parse(%s)", locStr)
+					return status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
+				}
 
-	// Wait for all DB workers to finish before closing the channel to signal the streamer to finish.
-	go func() {
+				// Query with the pool directly so each concurrent request gets a fresh connection.
+				// This is to avoid very large data requests choking the memory of the API.
+				// Normally I woudn't want to bypass SQLC's type safety - but this RPC is specifically for
+				// ML debugging and isn't on any hot path, so I don't mind here.
+				rows, err := pool.Query(
+					stream.Context(),
+					db.ListPredictionsForForecasts,
+					pgtype.Timestamp{
+						Time:  req.TimeWindow.StartTimestampUtc.AsTime(),
+						Valid: true,
+					},
+					pgtype.Timestamp{
+						Time:  req.TimeWindow.EndTimestampUtc.AsTime(),
+						Valid: true,
+					},
+					locationUuid,
+					int16(req.EnergySource.Number()),
+					fNames,
+					fVersions,
+				)
+				if err != nil {
+					l.Err(err).Msg("tx.Query(ListPredictionsForForecasts) failed")
+					return status.Errorf(codes.Internal, "Failed to stream predictions")
+				}
+				defer rows.Close()
+
+				batch := make([]*pb.ForecastDatum, 0, batchSize)
+
+				for rows.Next() {
+					var row db.ListPredictionsForForecastsRow
+
+					err := rows.Scan(
+						&row.InitTimeUtc,
+						&row.ForecasterName,
+						&row.ForecasterVersion,
+						&row.CreatedAtUtc,
+						&row.HorizonMins,
+						&row.P50Sip,
+						&row.OtherStatsFractions,
+						&row.CapacityWatts,
+						&row.Metadata,
+					)
+					if err != nil {
+						l.Err(err).Msg("rows.Scan failed")
+						return status.Errorf(codes.Internal, "Error reading prediction stream")
+					}
+
+					otherStatistics := make(map[string]float32)
+					if row.OtherStatsFractions != nil {
+						for k, v := range row.OtherStatsFractions.AsMap() {
+							otherStatistics[k] = float32(v.(float64))
+						}
+					}
+
+					metadata := make(map[string]string)
+					if req.IncludeMetadata && row.Metadata != nil {
+						for k, v := range row.Metadata.AsMap() {
+							metadata[k] = v.(string)
+						}
+					}
+
+					batch = append(batch, &pb.ForecastDatum{
+						InitTimestamp: timestamppb.New(row.InitTimeUtc.Time),
+						LocationUuid:  locationUuid.String(),
+						ForecasterFullname: fmt.Sprintf(
+							"%s:%s",
+							row.ForecasterName,
+							row.ForecasterVersion,
+						),
+						HorizonMins:              uint32(row.HorizonMins),
+						P50Fraction:              float32(row.P50Sip) / 30000.0,
+						OtherStatisticsFractions: otherStatistics,
+						CreatedTimestampUtc:      timestamppb.New(row.CreatedAtUtc.Time),
+						EffectiveCapacityWatts:   uint64(row.CapacityWatts),
+						Metadata:                 metadata,
+					})
+					if len(batch) == batchSize {
+						select {
+						case resChan <- &pb.StreamForecastDataResponse{Values: batch}:
+						case <-ctx.Done():
+							return ctx.Err()
+						}
+
+						batch = make([]*pb.ForecastDatum, 0, batchSize)
+					}
+				}
+
+				l.Debug().
+					Str("dp.geometry.uuid", locationUuid.String()).
+					Msg("streamed forecasts for location")
+
+				err = rows.Err()
+				if err != nil {
+					return err
+				}
+
+				if len(batch) > 0 {
+					select {
+					case resChan <- &pb.StreamForecastDataResponse{Values: batch}:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+
+				return nil
+			})
+		}
+
 		_ = eg.Wait()
 
 		close(resChan)
@@ -606,7 +634,18 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 		}
 	}
 
-	return eg.Wait()
+	// Finally, retrieve the actual error (if any) from the errgroup.
+	err := eg.Wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
+			l.Info().Msg("Stream gracefully cancelled by client")
+			return err
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -492,7 +492,7 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 	// Instantiate a worker pool of a limited size to handle the query.
 	// Handy blog on errgroups: https://oneuptime.com/blog/post/2026-01-07-go-errgroup
 	eg, ctx := errgroup.WithContext(stream.Context())
-	eg.SetLimit(int(pool.Config().MaxConns) - 1)
+	eg.SetLimit(2)
 	resChan := make(chan *pb.StreamForecastDataResponse, 100)
 
 	// Fan out queries for each location to the database.

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -2135,7 +2135,7 @@ func TestStreamForecastData(t *testing.T) {
 
 			var actualRowsCount int
 			for {
-				resp, err := stream.Recv()
+				batchResp, err := stream.Recv()
 				if err == io.EOF {
 					break
 				}
@@ -2146,20 +2146,22 @@ func TestStreamForecastData(t *testing.T) {
 				}
 
 				require.NoError(t, err)
-				require.NotNil(t, resp)
+				require.NotNil(t, batchResp)
 
-				actualRowsCount++
+				for _, pt := range batchResp.Values {
+					actualRowsCount++
 
-				if tc.checkMetadata {
-					require.NotNil(t, resp.Metadata)
-					require.Equal(t, "true", resp.Metadata["stream_test"])
-				} else {
-					require.Empty(t, resp.Metadata)
+					if tc.checkMetadata {
+						require.NotNil(t, pt.Metadata)
+						require.Equal(t, "true", pt.Metadata["stream_test"])
+					} else {
+						require.Empty(t, pt.Metadata)
+					}
+
+					require.NotZero(t, pt.EffectiveCapacityWatts)
+					require.NotNil(t, pt.OtherStatisticsFractions)
+					require.Contains(t, pt.OtherStatisticsFractions, "p90")
 				}
-
-				require.NotZero(t, resp.EffectiveCapacityWatts)
-				require.NotNil(t, resp.OtherStatisticsFractions)
-				require.Contains(t, resp.OtherStatisticsFractions, "p90")
 			}
 
 			if !tc.expectErr {

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -798,6 +798,10 @@ message StreamForecastDataRequest {
 }
 
 message StreamForecastDataResponse {
+  repeated ForecastDatum values = 1;
+}
+
+message ForecastDatum {
   google.protobuf.Timestamp init_timestamp = 1;
   string location_uuid = 2;
   string forecaster_fullname = 3;


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Modifies the StreamForecastData route to return its values in batches. This should be more stable and reduce CPU usage a bit. It does introduce a breaking change to the API, but since the Stream route is not on any hot path, I don't mind doing this. This is still in pre-1.0.0 after all.

The change is reflected in the example.py file, and boils down to data from the stream being under a `values` field, when previously it was returned top-level.
