### PR TITLE
feat(proto): Add GetLocationAsTimeseries route

### DIFF
--- a/internal/server/dummy/dataserverimpl.go
+++ b/internal/server/dummy/dataserverimpl.go
@@ -508,6 +508,22 @@ func (d *DataPlatformDataServiceServerImpl) GetLocation(
 	}, nil
 }
 
+// GetLocationAsTimeseries implements dp.DataPlatformDataServiceServer.
+func (d *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
+	ctx context.Context,
+	req *pb.GetLocationAsTimeseriesRequest,
+) (*pb.GetLocationAsTimeseriesResponse, error) {
+	return &pb.GetLocationAsTimeseriesResponse{
+		Values: []*pb.GetLocationAsTimeseriesResponse_LocationSnapshot{
+			{
+				EffectiveCapacityWatts: 150e6,
+				TimestampUtc:           timestamppb.New(time.Now().UTC()),
+				Metadata:               &structpb.Struct{},
+			},
+		},
+	}, nil
+}
+
 // ListLocations implements dp.DataPlatformDataServiceServer.
 func (d *DataPlatformDataServiceServerImpl) ListLocations(
 	context.Context,

--- a/internal/server/postgres/bench_test.go
+++ b/internal/server/postgres/bench_test.go
@@ -266,7 +266,7 @@ func BenchmarkPostgresClient(b *testing.B) {
 								ForecasterName:    tc.NamePrefix + "_forecaster_1",
 								ForecasterVersion: "v1",
 							}},
-							TimeWindow: &pb.StreamForecastDataRequest_TimeWindow{
+							TimeWindow: &pb.TimeWindow{
 								StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 48)),
 								EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 36)),
 							},

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -1236,6 +1236,54 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 	}, nil
 }
 
+func (s *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
+	ctx context.Context,
+	req *pb.GetLocationAsTimeseriesRequest,
+) (*pb.GetLocationAsTimeseriesResponse, error) {
+	l := zerolog.Ctx(ctx)
+
+	querier := db.New(ix.GetTxFromContext(ctx))
+
+	locationUuid := uuid.MustParse(req.LocationUuid)
+
+	gprms := db.GetSourceHistoryParams{
+		GeometryUuid: locationUuid,
+		SourceTypeID: int16(req.EnergySource.Number()),
+		StartTimestampUtc: pgtype.Timestamp{
+			Time:  req.TimeWindow.StartTimestampUtc.AsTime(),
+			Valid: true,
+		},
+		EndTimestampUtc: pgtype.Timestamp{
+			Time:  req.TimeWindow.EndTimestampUtc.AsTime(),
+			Valid: true,
+		},
+	}
+
+	dbValues, err := querier.GetSourceHistory(ctx, gprms)
+	if err != nil {
+		l.Err(err).Msgf("querier.GetSourceHistory(%+v)", gprms)
+
+		return nil, status.Errorf(
+			codes.NotFound,
+			"No such location or no history for location in the specified time window. "+
+				"Ensure the location exists and has source entries in the given time window.",
+		)
+	}
+
+	values := make([]*pb.GetLocationAsTimeseriesResponse_LocationSnapshot, len(dbValues))
+	for i, v := range dbValues {
+		values[i] = &pb.GetLocationAsTimeseriesResponse_LocationSnapshot{
+			EffectiveCapacityWatts: uint64(v.CapacityWatts),
+			TimestampUtc:           timestamppb.New(v.ValidFromUtc.Time),
+			Metadata:               v.Metadata,
+		}
+	}
+
+	return &pb.GetLocationAsTimeseriesResponse{
+		Values: values,
+	}, nil
+}
+
 func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 	ctx context.Context,
 	req *pb.CreateLocationRequest,

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -821,7 +821,7 @@ func TestGetLocationAsTimeseries(t *testing.T) {
 				LocationUuid: siteResp.LocationUuid,
 				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
 				TimeWindow: &pb.TimeWindow{
-					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 12)),
+					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 24)),
 					EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 10)),
 				},
 			},

--- a/internal/server/postgres/dataserverimpl_test.go
+++ b/internal/server/postgres/dataserverimpl_test.go
@@ -750,6 +750,144 @@ func TestGetLocation(t *testing.T) {
 	}
 }
 
+func TestGetLocationAsTimeseries(t *testing.T) {
+	pivotTime := time.Date(2026, 1, 4, 12, 0, 0, 0, time.UTC)
+
+	metadata, err := structpb.NewStruct(map[string]any{"source": "test_initial"})
+	require.NoError(t, err)
+
+	// Site is valid from 48 hours before pivot
+	siteResp, err := dc.CreateLocation(t.Context(), &pb.CreateLocationRequest{
+		LocationName:           "test_get_location_as_timeseries_site",
+		GeometryWkt:            "POINT(-60.25 57.5)",
+		EffectiveCapacityWatts: 1000000, // 1 MW
+		Metadata:               metadata,
+		EnergySource:           pb.EnergySource_ENERGY_SOURCE_SOLAR,
+		LocationType:           pb.LocationType_LOCATION_TYPE_SITE,
+		ValidFromUtc:           timestamppb.New(pivotTime.Add(-time.Hour * 48)),
+	})
+	require.NoError(t, err)
+
+	// Update the metadata and capacity at 24 hours before pivot
+	updatedMetadata, err := structpb.NewStruct(map[string]any{"source": "test_update_1"})
+	require.NoError(t, err)
+	_, err = dc.UpdateLocation(t.Context(), &pb.UpdateLocationRequest{
+		LocationUuid:              siteResp.LocationUuid,
+		EnergySource:              pb.EnergySource_ENERGY_SOURCE_SOLAR,
+		NewEffectiveCapacityWatts: func() *uint64 { v := uint64(1500000); return &v }(), // 1.5 MW
+		NewMetadata:               updatedMetadata,
+		ValidFromUtc:              timestamppb.New(pivotTime.Add(-time.Hour * 24)),
+	})
+	require.NoError(t, err)
+
+	// Update the metadata and capacity again at pivot
+	finalMetadata, err := structpb.NewStruct(map[string]any{"source": "test_update_2"})
+	require.NoError(t, err)
+	_, err = dc.UpdateLocation(t.Context(), &pb.UpdateLocationRequest{
+		LocationUuid:              siteResp.LocationUuid,
+		EnergySource:              pb.EnergySource_ENERGY_SOURCE_SOLAR,
+		NewEffectiveCapacityWatts: func() *uint64 { v := uint64(2000000); return &v }(), // 2.0 MW
+		NewMetadata:               finalMetadata,
+		ValidFromUtc:              timestamppb.New(pivotTime),
+	})
+	require.NoError(t, err)
+
+	defaultTimeWindow := &pb.TimeWindow{
+		StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 50)),
+		EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 10)),
+	}
+
+	testcases := []struct {
+		name               string
+		req                *pb.GetLocationAsTimeseriesRequest
+		expectedCapacities []uint64
+		expectedSources    []string
+		expectErr          bool
+	}{
+		{
+			name: "Should return full history of capacity changes when window covers everything",
+			req: &pb.GetLocationAsTimeseriesRequest{
+				LocationUuid: siteResp.LocationUuid,
+				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				TimeWindow:   defaultTimeWindow,
+			},
+			expectedCapacities: []uint64{1000000, 1500000, 2000000},
+			expectedSources:    []string{"test_initial", "test_update_1", "test_update_2"},
+			expectErr:          false,
+		},
+		{
+			name: "Should return only changes covered by time window and exclude others",
+			req: &pb.GetLocationAsTimeseriesRequest{
+				LocationUuid: siteResp.LocationUuid,
+				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				TimeWindow: &pb.TimeWindow{
+					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 12)),
+					EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 10)),
+				},
+			},
+			expectedCapacities: []uint64{1500000, 2000000},
+			expectedSources:    []string{"test_update_1", "test_update_2"},
+			expectErr:          false,
+		},
+		{
+			name: "Should return no values if time window is before the location existed",
+			req: &pb.GetLocationAsTimeseriesRequest{
+				LocationUuid: siteResp.LocationUuid,
+				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				TimeWindow: &pb.TimeWindow{
+					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 100)),
+					EndTimestampUtc:   timestamppb.New(pivotTime.Add(-time.Hour * 50)),
+				},
+			},
+			expectedCapacities: []uint64{},
+			expectedSources:    []string{},
+			expectErr:          false,
+		},
+		{
+			name: "Shouldn't work with an invalid UUID",
+			req: &pb.GetLocationAsTimeseriesRequest{
+				LocationUuid: "not-a-valid-uuid",
+				EnergySource: pb.EnergySource_ENERGY_SOURCE_SOLAR,
+				TimeWindow:   defaultTimeWindow,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := dc.GetLocationAsTimeseries(t.Context(), tc.req)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			actualCapacities := make([]uint64, len(resp.Values))
+			actualSources := make([]string, len(resp.Values))
+			targetTimes := make([]int64, len(resp.Values))
+
+			for i, v := range resp.Values {
+				actualCapacities[i] = v.EffectiveCapacityWatts
+				targetTimes[i] = v.TimestampUtc.AsTime().Unix()
+
+				if v.Metadata != nil && v.Metadata.Fields["source"] != nil {
+					actualSources[i] = v.Metadata.Fields["source"].GetStringValue()
+				} else {
+					actualSources[i] = ""
+				}
+			}
+
+			require.IsIncreasing(t, targetTimes)
+			require.Equal(t, tc.expectedCapacities, actualCapacities)
+			require.Equal(t, tc.expectedSources, actualSources)
+		})
+	}
+}
+
 func TestGetLocationsAsGeoJSON(t *testing.T) {
 	// Create some locations
 	siteUuids := make([]string, 3)
@@ -846,7 +984,6 @@ func TestGetForecastAsTimeseries(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Standardise the time window reused across most requests
 	defaultTimeWindow := &pb.TimeWindow{
 		StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 48)),
 		EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 36)),
@@ -1978,7 +2115,7 @@ func TestGetLatestForecasts(t *testing.T) {
 }
 
 func TestStreamForecastData(t *testing.T) {
-	pivotTime := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	pivotTime := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 
 	// Create a site to attach the forecasts to
 	metadata, err := structpb.NewStruct(map[string]any{"stream_test": "true"})
@@ -2043,7 +2180,7 @@ func TestStreamForecastData(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	defaultTimeWindow := &pb.StreamForecastDataRequest_TimeWindow{
+	defaultTimeWindow := &pb.TimeWindow{
 		StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Hour * 10)),
 		EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Hour * 10)),
 	}
@@ -2087,7 +2224,7 @@ func TestStreamForecastData(t *testing.T) {
 				LocationUuids: []string{siteResp.LocationUuid},
 				EnergySource:  pb.EnergySource_ENERGY_SOURCE_SOLAR,
 				Forecasters:   []*pb.Forecaster{fc1Resp.Forecaster},
-				TimeWindow: &pb.StreamForecastDataRequest_TimeWindow{
+				TimeWindow: &pb.TimeWindow{
 					// Constrain the window to only capture the most recent forecast
 					StartTimestampUtc: timestamppb.New(pivotTime.Add(-time.Minute * 10)),
 					EndTimestampUtc:   timestamppb.New(pivotTime.Add(time.Minute * 10)),

--- a/internal/server/postgres/sql/queries/locations.sql
+++ b/internal/server/postgres/sql/queries/locations.sql
@@ -150,9 +150,13 @@ INSERT INTO loc.sources_history (
 SELECT
     sh.capacity_watts,
     sh.capacity_limit_sip,
-    sh.valid_from_utc
+    sh.valid_from_utc,
+    sh.metadata
 FROM loc.sources_history AS sh
-WHERE sh.geometry_uuid = $1 AND sh.source_type_id = $2
+WHERE sh.geometry_uuid = $1
+    AND sh.source_type_id = $2
+    AND sh.valid_from_utc >= sqlc.arg(start_timestamp_utc)::TIMESTAMP
+    AND sh.valid_from_utc < sqlc.arg(end_timestamp_utc)::TIMESTAMP
 ORDER BY valid_from_utc DESC;
 
 -- name: ListSourcesAtTimestamp :many

--- a/internal/server/postgres/sql/queries/locations.sql
+++ b/internal/server/postgres/sql/queries/locations.sql
@@ -157,7 +157,7 @@ WHERE sh.geometry_uuid = $1
     AND sh.source_type_id = $2
     AND sh.valid_from_utc >= sqlc.arg(start_timestamp_utc)::TIMESTAMP
     AND sh.valid_from_utc < sqlc.arg(end_timestamp_utc)::TIMESTAMP
-ORDER BY valid_from_utc DESC;
+ORDER BY valid_from_utc ASC;
 
 -- name: ListSourcesAtTimestamp :many
 /* ListSourcesAtTimestamp returns all sources that match the given filters.

--- a/proto/ocf/dp/dp-data.messages.proto
+++ b/proto/ocf/dp/dp-data.messages.proto
@@ -29,12 +29,7 @@ message TimeWindow {
    */
   google.protobuf.Timestamp start_timestamp_utc = 1 [
     (buf.validate.field).required = true,
-    (buf.validate.field).timestamp = { gt: { seconds: 112000000} },
-    (buf.validate.field).cel = {
-      id: "timestamp_not_too_far_in_future"
-      message: "start_timestamp_utc cannot be more than 30 days in the future"
-      expression: "this <= now + duration('720h')"
-    }
+    (buf.validate.field).timestamp = { gt: { seconds: 112000000} }
   ];
   /* The end of the time window, inclusive.
    * Cannot be more than 7 days after start_timestamp_utc.
@@ -44,11 +39,6 @@ message TimeWindow {
     (buf.validate.field).timestamp.gt = { seconds: 112000000}
   ];
 
-  option (buf.validate.message).cel = {
-    id: "maximum_window_size"
-    message: "window size must not exceed 7 days"
-    expression: "this.end_timestamp_utc - this.start_timestamp_utc <= duration('604800s')"
-  };
   option (buf.validate.message).cel = {
     id: "start_before_end"
     message: "start_timestamp_utc must be before end_timestamp_utc"
@@ -69,7 +59,17 @@ message GetForecastAsTimeseriesRequest {
 
   uint32 horizon_mins = 3;
   TimeWindow time_window = 4 [
-    (buf.validate.field).required = true
+    (buf.validate.field).required = true,
+    (buf.validate.field).cel = {
+      id: "window_size_limit"
+      message: "window size must not exceed 7 days"
+      expression: "this.end_timestamp_utc - this.start_timestamp_utc <= duration('168h')"
+    },
+    (buf.validate.field).cel = {
+      id: "start_time_near_future_limit"
+      message: "start time cannot be more than 30 days in the future"
+      expression: "this.start_timestamp_utc <= now + duration('720h')"
+    }
   ];
   Forecaster forecaster = 5 [
     (buf.validate.field).required = true
@@ -128,7 +128,17 @@ message GetObservationsAsTimeseriesRequest {
     (buf.validate.field).required = true 
   ];
   TimeWindow time_window = 4 [
-    (buf.validate.field).required = true
+    (buf.validate.field).required = true,
+    (buf.validate.field).cel = {
+      id: "window_size_limit"
+      message: "window size must not exceed 7 days"
+      expression: "this.end_timestamp_utc - this.start_timestamp_utc <= duration('168h')"
+    },
+    (buf.validate.field).cel = {
+      id: "start_time_near_future_limit"
+      message: "start time cannot be more than 30 days in the future"
+      expression: "this.start_timestamp_utc <= now + duration('720h')"
+    }
   ];
 }
 
@@ -476,6 +486,38 @@ message GetLocationResponse {
   optional bytes geometry_wkb = 6;
 }
 
+message GetLocationAsTimeseriesRequest {
+  string location_uuid = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+  EnergySource energy_source = 2 [
+    (buf.validate.field).required = true 
+  ];
+  TimeWindow time_window = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).cel = {
+      id: "window_size_limit"
+      message: "window size must not exceed 1 year"
+      expression: "this.end_timestamp_utc - this.start_timestamp_utc <= duration('8760h')"
+    },
+    (buf.validate.field).cel = {
+      id: "start_time_near_future_limit"
+      message: "start time cannot be more than 30 days in the future"
+      expression: "this.start_timestamp_utc <= now + duration('720h')"
+    }
+  ];
+}
+
+message GetLocationAsTimeseriesResponse {
+  message LocationSnapshot {
+    google.protobuf.Timestamp timestamp_utc = 1;
+    uint64 effective_capacity_watts = 2;
+    google.protobuf.Struct metadata = 3;
+  }
+  repeated LocationSnapshot values = 1;
+}
+
 message UpdateLocationRequest {
   string location_uuid = 1 [
     (buf.validate.field).required = true,
@@ -747,34 +789,6 @@ message ListLocationsResponse {
 
 
 message StreamForecastDataRequest {
-  message TimeWindow {
-    /* The start of the time window, inclusive.
-     * Cannot be more than 31 days before end_timestamp_utc.
-     */
-    google.protobuf.Timestamp start_timestamp_utc = 1 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).timestamp = { gt: { seconds: 112000000}, lt_now: true }
-    ];
-    /* The end of the time window, inclusive.
-     * Cannot be more than 31 days after start_timestamp_utc.
-     */
-    google.protobuf.Timestamp end_timestamp_utc = 2 [
-      (buf.validate.field).required = true,
-      (buf.validate.field).timestamp.gt = { seconds: 112000000}
-    ];
-
-    option (buf.validate.message).cel = {
-      id: "maximum_window_size"
-      message: "window size must not exceed 31 days"
-      expression: "this.end_timestamp_utc - this.start_timestamp_utc <= duration('2678400s')"
-    };
-    option (buf.validate.message).cel = {
-      id: "start_before_end"
-      message: "start_timestamp_utc must be before end_timestamp_utc"
-      expression: "this.start_timestamp_utc <= this.end_timestamp_utc"
-    };
-  }
-
   repeated string location_uuids = 1 [
     (buf.validate.field).repeated.min_items = 1,
     (buf.validate.field).repeated.max_items = 1000,
@@ -786,8 +800,18 @@ message StreamForecastDataRequest {
   EnergySource energy_source = 2 [
     (buf.validate.field).required = true 
   ];
-  StreamForecastDataRequest.TimeWindow time_window = 3 [
-    (buf.validate.field).required = true
+  TimeWindow time_window = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).cel = {
+      id: "window_size_limit"
+      message: "window size must not exceed 31 days"
+      expression: "this.end_timestamp_utc - this.start_timestamp_utc <= duration('744h')"
+    },
+    (buf.validate.field).cel = {
+      id: "start_time_near_future_limit"
+      message: "start time cannot be more than 30 days in the future"
+      expression: "this.start_timestamp_utc <= now + duration('720h')"
+    }
   ];
   repeated Forecaster forecasters = 4 [
     (buf.validate.field).required = true,

--- a/proto/ocf/dp/dp-data.service.proto
+++ b/proto/ocf/dp/dp-data.service.proto
@@ -27,8 +27,10 @@ service DataPlatformDataService {
    */
   rpc GetObservationsAtTimestamp(GetObservationsAtTimestampRequest) returns (GetObservationsAtTimestampResponse) {}
 
-  /* GetLocation fetches detailed information about a specific location. */
+  /* GetLocation fetches detailed information about a specific location at a specific time. */
   rpc GetLocation(GetLocationRequest) returns (GetLocationResponse) {}
+  /* GetLocationAsTimeseries fetches the history of a location across a given time window. */
+  rpc GetLocationAsTimeseries(GetLocationAsTimeseriesRequest) returns (GetLocationAsTimeseriesResponse) {}
   /* CreateLocation registers a new location in which to log or forecast generation. */
   rpc CreateLocation(CreateLocationRequest) returns (CreateLocationResponse) {}
   /* UpdateLocation modifies various attributes associated with a given location. */


### PR DESCRIPTION
### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.


### Changes in this Pull Request

Adds a GetLocationAsTimeseries route which returns the capacity values for a given time window.
