### PR TITLE
fix: Transparent gRPC errors

### DIFF
--- a/internal/interceptors/transaction.go
+++ b/internal/interceptors/transaction.go
@@ -95,13 +95,12 @@ func NewTransactionInterceptor(
 	return &transactionInterceptorBuilder{pool: pool}
 }
 
-
 // mapErrorToGRPC maps database errors to appropriate gRPC status codes.
 func mapErrorToGRPC(err error) error {
 	if err == nil {
 		return nil
 	}
-	
+
 	// Pass through existing gRPC status errors explicitly
 	if _, ok := status.FromError(err); ok {
 		return err
@@ -118,7 +117,9 @@ func mapErrorToGRPC(err error) error {
 			return status.Error(codes.AlreadyExists, err.Error())
 		case "23503": // foreign_key_violation
 			return status.Error(codes.FailedPrecondition, err.Error())
-		case "23514", "23502", "22P02": // check_violation, not_null_violation, invalid_text_representation
+		case "23514",
+			"23502",
+			"22P02": // check_violation, not_null_violation, invalid_text_representation
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
 	}

--- a/internal/interceptors/transaction.go
+++ b/internal/interceptors/transaction.go
@@ -4,7 +4,9 @@ package interceptors
 import (
 	"context"
 	"embed"
+	"errors"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/jackc/pgx/v5"
@@ -93,6 +95,37 @@ func NewTransactionInterceptor(
 	return &transactionInterceptorBuilder{pool: pool}
 }
 
+
+// mapErrorToGRPC maps database errors to appropriate gRPC status codes.
+func mapErrorToGRPC(err error) error {
+	if err == nil {
+		return nil
+	}
+	
+	// Pass through existing gRPC status errors explicitly
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return status.Error(codes.NotFound, err.Error())
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505": // unique_violation
+			return status.Error(codes.AlreadyExists, err.Error())
+		case "23503": // foreign_key_violation
+			return status.Error(codes.FailedPrecondition, err.Error())
+		case "23514", "23502", "22P02": // check_violation, not_null_violation, invalid_text_representation
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
+
+	return status.Error(codes.Internal, err.Error())
+}
+
 // UnaryServerInterceptor is the gRPC interceptor for handling transactions.
 func (ti *transactionInterceptorBuilder) UnaryServerInterceptor(
 	ctx context.Context,
@@ -123,7 +156,7 @@ func (ti *transactionInterceptorBuilder) UnaryServerInterceptor(
 	// Call the original RPC handler with the new context.
 	resp, err := handler(txCtx, req)
 	if err != nil {
-		return nil, err
+		return nil, mapErrorToGRPC(err)
 	}
 
 	return resp, nil
@@ -148,7 +181,7 @@ func (ti *transactionInterceptorBuilder) StreamServerInterceptor(
 	// Wrap the ServerStream to inject our new context.
 	err := handler(srv, &wrappedStream{ServerStream: ss, newCtx: poolCtx})
 	if err != nil {
-		return err
+		return mapErrorToGRPC(err)
 	}
 
 	return nil

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -28,6 +29,27 @@ import (
 )
 
 // --- Reuseable Functions for Route Logic -------------------------------------------------------
+
+// handleDBError maps database errors to appropriate gRPC status codes.
+func handleDBError(err error, msg string) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return status.Errorf(codes.NotFound, "%s: %v", msg, err)
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505": // unique_violation
+			return status.Errorf(codes.AlreadyExists, "%s: %v", msg, err)
+		case "23503": // foreign_key_violation
+			return status.Errorf(codes.FailedPrecondition, "%s: %v", msg, err)
+		case "23514", "23502", "22P02": // check_violation, not_null_violation, invalid_text_representation
+			return status.Errorf(codes.InvalidArgument, "%s: %v", msg, err)
+		}
+	}
+
+	return status.Errorf(codes.Internal, "%s: %v", msg, err)
+}
 
 // timeWindowToPgWindow converts a TimeWindow protobuf message to a pair of pgtype.Timestamp values.
 func timeWindowToPgWindow(
@@ -107,13 +129,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetSourceAtTimestamp(%+v)", gsprms)
-
-		return nil, status.Error(
-			codes.NotFound, "No location found."+
-				"Ensure the location exists, and has a registered capacity value "+
-				"for the given energy type valid for before the forecast init time.",
-		)
+		return nil, handleDBError(err, "No location found. Ensure the location exists, and has a registered capacity value for the given energy type valid for before the forecast init time.")
 	}
 
 	l.Debug().Str("dp.geometry.uuid", dbSource.GeometryUuid.String()).
@@ -142,12 +158,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetForecasterElseLatest(%+v)", pctprms)
-
-		return nil, status.Error(
-			codes.NotFound, "No such forecaster. "+
-				"Create the forecaster before submitting a forecast.",
-		)
+		return nil, handleDBError(err, "No such forecaster. Create the forecaster before submitting a forecast.")
 	}
 
 	l.Debug().
@@ -172,12 +183,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecast, err := querier.CreateForecast(ctx, cfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateForecast(%+v)", cfprms)
-
-		return nil, status.Error(
-			codes.InvalidArgument, "Invalid forecast. Ensure the forecast has a valid init_time "+
-				"and horizon values.",
-		)
+		return nil, handleDBError(err, "Invalid forecast. Ensure the forecast has a valid init_time and horizon values.")
 	}
 
 	// Create the forecast data
@@ -198,12 +204,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	count, err := querier.CreatePredictedValues(ctx, paramsList)
 	if err != nil || count < int64(len(req.Values)) {
-		l.Err(err).Msgf("querier.CreatePredictedValues(%+v)", paramsList)
-
-		return nil, status.Error(
-			codes.InvalidArgument, "Invalid predicted generation values. "+
-				"Ensure the values are positive and correspond to less than 110% of capacity.",
-		)
+		if err == nil {
+			err = errors.New("inserted count less than requested")
+		}
+		return nil, handleDBError(err, "Invalid predicted generation values. Ensure the values are positive and correspond to less than 110% of capacity.")
 	}
 
 	l.Debug().
@@ -226,8 +230,6 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 	ctx context.Context,
 	req *pb.DeleteForecastRequest,
 ) (*pb.DeleteForecastResponse, error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	// Check the forecaster exists
@@ -238,12 +240,7 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetForecasterElseLatest(%+v)", pctprms)
-
-		return nil, status.Error(
-			codes.NotFound, "No such forecaster. "+
-				"Create the forecaster before submitting a forecast.",
-		)
+		return nil, handleDBError(err, "No such forecaster. Create the forecaster before submitting a forecast.")
 	}
 
 	// Delete the forecast
@@ -256,12 +253,7 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 
 	err = querier.DeleteForecast(ctx, dfcprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.DeleteForecast(%+v)", dfcprms)
-
-		return nil, status.Error(
-			codes.Internal,
-			"Could not delete forecast. Ensure the forecast exists.",
-		)
+		return nil, handleDBError(err, "Could not delete forecast. Ensure the forecast exists.")
 	}
 
 	return &pb.DeleteForecastResponse{}, nil
@@ -286,12 +278,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestForecasts(
 
 	dbListForecasts, err := querier.GetLatestForecastsAtHorizonSincePivot(ctx, glfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetLatestForecastsAtHorizonSincePivot(%+v)", glfprms)
-
-		return nil, status.Error(
-			codes.NotFound,
-			"No forecasts found. Ensure location exists and forecasts have been created for it.",
-		)
+		return nil, handleDBError(err, "No forecasts found. Ensure location exists and forecasts have been created for it.")
 	}
 
 	l.Debug().Str("dp.geometry.uuid", req.LocationUuid).
@@ -335,7 +322,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecaster(
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, gpprms)
 	if err == nil {
 		return nil, status.Errorf(
-			codes.InvalidArgument,
+			codes.AlreadyExists,
 			"Forecaster with already exists (at version '%s'). "+
 				"Use the update method to add a new version, or create a new forecaster.",
 			dbExistingForecaster.ForecasterVersion,
@@ -347,12 +334,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateForecaster(%+v)", cfprms)
-
-		return nil, status.Errorf(
-			codes.InvalidArgument,
-			"Invalid forecaster. Ensure name and version are not empty and are lowercase",
-		)
+		return nil, handleDBError(err, "Invalid forecaster. Ensure name and version are not empty and are lowercase")
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -380,10 +362,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateForecaster(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, gpprms)
 	if err != nil {
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"No such forecaster. Use the create method to add it.",
-		)
+		return nil, handleDBError(err, "No such forecaster. Use the create method to add it.")
 	}
 
 	// Update the forecaster
@@ -394,13 +373,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateForecaster(%+v)", cfprms)
-
-		return nil, status.Errorf(
-			codes.InvalidArgument,
-			"Invalid forecaster. Ensure name and version are not empty and are lowercase, "+
-				"and name is unique.",
-		)
+		return nil, handleDBError(err, "Invalid forecaster. Ensure name and version are not empty and are lowercase, and name is unique.")
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -418,7 +391,6 @@ func (s *DataPlatformDataServiceServerImpl) ListForecasters(
 	ctx context.Context,
 	req *pb.ListForecastersRequest,
 ) (*pb.ListForecastersResponse, error) {
-	l := zerolog.Ctx(ctx)
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	lfprms := db.GetForecastersByFiltersParams{
@@ -428,12 +400,7 @@ func (s *DataPlatformDataServiceServerImpl) ListForecasters(
 
 	dbListForecasters, err := querier.GetForecastersByFilters(ctx, lfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetForecastersByFilters(%+v)", lfprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No forecasters found with the specified filters",
-		)
+		return nil, handleDBError(err, "No forecasters found with the specified filters")
 	}
 
 	forecasters := make([]*pb.Forecaster, len(dbListForecasters))
@@ -487,7 +454,6 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 
 				locationUuid, err := uuid.Parse(locStr)
 				if err != nil {
-					l.Err(err).Msgf("uuid.Parse(%s)", locStr)
 					return status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
 				}
 
@@ -512,8 +478,7 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 					fVersions,
 				)
 				if err != nil {
-					l.Err(err).Msg("tx.Query(ListPredictionsForForecasts) failed")
-					return status.Errorf(codes.Internal, "Failed to stream predictions")
+					return handleDBError(err, "Failed to stream predictions")
 				}
 				defer rows.Close()
 
@@ -540,8 +505,7 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 						&row.TargetTimeUtc,
 					)
 					if err != nil {
-						l.Err(err).Msg("rows.Scan failed")
-						return status.Errorf(codes.Internal, "Error reading prediction stream")
+						return status.Errorf(codes.Internal, "Error reading prediction stream: %v", err)
 					}
 
 					otherStatistics := make(map[string]float32)
@@ -655,14 +619,11 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 	ctx context.Context,
 	req *pb.GetWeekAverageDeltasRequest,
 ) (*pb.GetWeekAverageDeltasResponse, error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	// Get the location and source
 	locationUuid, err := uuid.Parse(req.LocationUuid)
 	if err != nil {
-		l.Err(err).Msgf("uuid.Parse(%s)", req.LocationUuid)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
 	}
 
@@ -674,12 +635,7 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gstprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetSourceAtTimestamp(%+v)", gstprms)
-
-		return nil, status.Errorf(
-			codes.NotFound, "No location source found for name '%s' with source type '%s'.",
-			req.LocationUuid, req.EnergySource,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No location source found for name '%s' with source type '%s'", req.LocationUuid, req.EnergySource))
 	}
 
 	// Get the relevant forecaster
@@ -690,12 +646,7 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetForecasterElseLatest(%+v)", pctprms)
-
-		return nil, status.Errorf(
-			codes.NotFound, "No forecaster found for name '%s' and version '%s'.",
-			req.Forecaster.ForecasterName, req.Forecaster.ForecasterVersion,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No forecaster found for name '%s' and version '%s'", req.Forecaster.ForecasterName, req.Forecaster.ForecasterVersion))
 	}
 
 	// Get the observer
@@ -703,13 +654,7 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetObserverByName(%+v)", obprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No observer of name '%s' found. Choose an existing observer or create a new one.",
-			req.ObserverName,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s' found. Choose an existing observer or create a new one.", req.ObserverName))
 	}
 
 	// Get the deltas
@@ -723,15 +668,7 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbDeltas, err := querier.GetWeekAverageDeltasForLocations(ctx, avgprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetWeekAverageDeltasForLocations(%+v)", avgprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No deltas found for location '%s' with source type '%s' and observer ID '%s'",
-			req.LocationUuid,
-			req.EnergySource,
-			dbObserver.ObserverUuid.String(),
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No deltas found for location '%s' with source type '%s' and observer ID '%s'", req.LocationUuid, req.EnergySource, dbObserver.ObserverUuid.String()))
 	}
 
 	// Convert the deltas to the response format
@@ -756,8 +693,6 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 	ctx context.Context,
 	req *pb.GetObservationsAsTimeseriesRequest,
 ) (*pb.GetObservationsAsTimeseriesResponse, error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 	locationUuid := uuid.MustParse(req.LocationUuid)
 
@@ -766,18 +701,11 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 
 	observerResp, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetObserverByName(%+v)", obprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No observer of name '%s' found. Choose an existing observer or create a new one.",
-			req.ObserverName,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s' found. Choose an existing observer or create a new one.", req.ObserverName))
 	}
 
 	start, end, err := timeWindowToPgWindow(req.TimeWindow)
 	if err != nil {
-		l.Err(err).Msgf("timeWindowToPgWindow(%+v)", req.TimeWindow)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid time window: %v", err)
 	}
 
@@ -791,13 +719,7 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 
 	dbObs, err := querier.GetObservationsBetween(ctx, goprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetObservationsBetween(%+v)", goprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No observations found for location '%s'",
-			req.LocationUuid,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No observations found for location '%s'", req.LocationUuid))
 	}
 
 	values := make([]*pb.GetObservationsAsTimeseriesResponse_Value, len(dbObs))
@@ -826,7 +748,6 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 	// Get the location and source
 	locationUuid, err := uuid.Parse(req.LocationUuid)
 	if err != nil {
-		l.Err(err).Msgf("uuid.Parse(%s)", req.LocationUuid)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
 	}
 
@@ -838,12 +759,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetUserSourceAtTimestamp(%+v)", cfprms)
-
-		return nil, status.Errorf(
-			codes.NotFound, "No location found for name '%s' with source type '%s'.",
-			req.LocationUuid, req.EnergySource,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No location found for name '%s' with source type '%s'", req.LocationUuid, req.EnergySource))
 	}
 
 	// Get the observer ID
@@ -851,13 +767,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetObserverByName(%+v)", obprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No observer of name '%s', found. Choose an existing observer or create a new one.",
-			req.ObserverName,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s', found. Choose an existing observer or create a new one.", req.ObserverName))
 	}
 
 	// Insert the observations
@@ -879,12 +789,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	err = batch.Close()
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateObservationsBatch(%+v)", coprms)
-
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"Invalid observation values. Ensure the values are positive, and less than 110% of capacity.",
-		)
+		return nil, handleDBError(err, "Invalid observation values. Ensure the values are positive, and less than 110% of capacity.")
 	}
 
 	l.Debug().Int16("dp.source.type_id", dbSource.SourceTypeID).
@@ -928,12 +833,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestObservations(
 
 	dbObs, err := querier.GetLatestObservations(ctx, goprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetLatestObservation(%+v)", goprms)
-
-		return nil, status.Error(
-			codes.Internal,
-			"Backend communication error. See logs for details.",
-		)
+		return nil, handleDBError(err, "Backend communication error")
 	}
 
 	observations := make([]*pb.GetLatestObservationsResponse_Observation, len(dbObs))
@@ -961,20 +861,13 @@ func (s *DataPlatformDataServiceServerImpl) CreateObserver(
 	ctx context.Context,
 	req *pb.CreateObserverRequest,
 ) (*pb.CreateObserverResponse, error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	obprms := db.CreateObserverParams{ObserverName: req.Name}
 
 	dbObserver, err := querier.CreateObserver(ctx, obprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateObserver(%+v)", obprms)
-
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"Invalid observer name. Ensure it is not empty, unique, and lowercase",
-		)
+		return nil, handleDBError(err, "Invalid observer name. Ensure it is not empty, unique, and lowercase")
 	}
 
 	return &pb.CreateObserverResponse{
@@ -996,12 +889,7 @@ func (s *DataPlatformDataServiceServerImpl) ListObservers(
 
 	dbListObservers, err := querier.GetObserversByFilters(ctx, loPrms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetObserversByFilters(%+v)", loPrms)
-
-		return nil, status.Errorf(
-			codes.Internal,
-			"Backend communication error. See logs for details.",
-		)
+		return nil, handleDBError(err, "Backend communication error")
 	}
 
 	l.Debug().
@@ -1042,12 +930,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, cfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetForecasterElseLatest(%+v)", cfprms)
-
-		return nil, status.Errorf(
-			codes.NotFound, "No forecaster found for name '%s' and version '%s'.",
-			req.Forecaster.ForecasterName, req.Forecaster.ForecasterVersion,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No forecaster found for name '%s' and version '%s'", req.Forecaster.ForecasterName, req.Forecaster.ForecasterVersion))
 	}
 
 	l.Debug().
@@ -1071,12 +954,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbPredictions, err := querier.ListPredictionsAtTimeForLocations(ctx, lpprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.ListPredictionsAtTimeForLocations(%+v)", lpprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No predicted values found for the specified locations at the given time.",
-		)
+		return nil, handleDBError(err, "No predicted values found for the specified locations at the given time.")
 	}
 
 	values := make([]*pb.GetForecastAtTimestampResponse_Value, len(dbPredictions))
@@ -1132,8 +1010,6 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 	ctx context.Context,
 	req *pb.GetObservationsAtTimestampRequest,
 ) (*pb.GetObservationsAtTimestampResponse, error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	// Set default timestamp to now if not provided
@@ -1151,13 +1027,7 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetObserverByName(%+v)", obprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No observer of name '%s' found. Choose an existing observer or create a new one.",
-			req.ObserverName,
-		)
+		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s' found. Choose an existing observer or create a new one.", req.ObserverName))
 	}
 
 	loprms := db.ListObservationsAtTimeForLocationsParams{
@@ -1169,13 +1039,7 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObs, err := querier.ListObservationsAtTimeForLocations(ctx, loprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.ListObservationsAtTimeForLocations(%+v)", loprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No observations found for the specified locations at the given time. "+
-				"Ensure the observer exists, and that the location is operational.",
-		)
+		return nil, handleDBError(err, "No observations found for the specified locations at the given time. Ensure the observer exists, and that the location is operational.")
 	}
 
 	observations := make([]*pb.GetObservationsAtTimestampResponse_Value, len(dbObs))
@@ -1218,12 +1082,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetSourceAtTimestamp(%+v)", cfprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No such location. Ensure the location exists and is currently operational.",
-		)
+		return nil, handleDBError(err, "No such location. Ensure the location exists and is currently operational.")
 	}
 
 	l.Debug().
@@ -1241,12 +1100,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 
 		dbGeometry, err := querier.GetGeometryWKB(ctx, gwkbprms)
 		if err != nil {
-			l.Err(err).Msgf("querier.GetGeometryWKB(%+v)", gwkbprms)
-
-			return nil, status.Errorf(
-				codes.Internal,
-				"Failed to retrieve geometry for location. See logs for details.",
-			)
+			return nil, handleDBError(err, "Failed to retrieve geometry for location")
 		}
 
 		geometry = dbGeometry.GeomWkb
@@ -1269,8 +1123,6 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
 	ctx context.Context,
 	req *pb.GetLocationAsTimeseriesRequest,
 ) (*pb.GetLocationAsTimeseriesResponse, error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	locationUuid := uuid.MustParse(req.LocationUuid)
@@ -1290,13 +1142,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
 
 	dbValues, err := querier.GetSourceHistory(ctx, gprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetSourceHistory(%+v)", gprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"No such location or no history for location in the specified time window. "+
-				"Ensure the location exists and has source entries in the given time window.",
-		)
+		return nil, handleDBError(err, "No such location or no history for location in the specified time window. Ensure the location exists and has source entries in the given time window.")
 	}
 
 	values := make([]*pb.GetLocationAsTimeseriesResponse_LocationSnapshot, len(dbValues))
@@ -1340,12 +1186,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbLocation, err := querier.CreateGeometry(ctx, cgprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateLocation(%+v)", cgprms)
-
-		return nil, status.Error(
-			codes.InvalidArgument, "Invalid location. Ensure name is not empty, "+
-				"and that geometry is valid, closed, unique WGS84.",
-		)
+		return nil, handleDBError(err, "Invalid location. Ensure name is not empty, and that geometry is valid, closed, unique WGS84.")
 	}
 
 	l.Debug().
@@ -1372,12 +1213,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbSource, err := querier.CreateSourceEntry(ctx, csprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.CreateSourceEntry(%+v)", csprms)
-
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"Invalid location. Ensure metadata is NULL or a non-empty JSON object.",
-		)
+		return nil, handleDBError(err, "Invalid location. Ensure metadata is NULL or a non-empty JSON object.")
 	}
 
 	l.Debug().
@@ -1389,8 +1225,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	err = querier.RefreshSourcesMaterializedView(ctx)
 	if err != nil {
-		l.Err(err).Msg("querier.RefreshSourcesMaterializedView()")
-		return nil, status.Error(codes.Internal, "Failed to update sources materialised view")
+		return nil, handleDBError(err, "Failed to update sources materialised view")
 	}
 
 	l.Debug().Msg("refreshed sources materialised view")
@@ -1433,12 +1268,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, lsprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetSourceAtTimestamp(%+v)", lsprms)
-
-		return nil, status.Errorf(
-			codes.NotFound,
-			"Location does not exist. Create the location before attempting to update capacity.",
-		)
+		return nil, handleDBError(err, "Location does not exist. Create the location before attempting to update capacity.")
 	}
 
 	l.Debug().
@@ -1468,12 +1298,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 		_, err = querier.RenameGeometry(ctx, rgprms)
 		if err != nil {
-			l.Err(err).Msgf("querier.RenameGeometry(%+v)", rgprms)
-
-			return nil, status.Error(
-				codes.InvalidArgument,
-				"Invalid location name. Ensure new name is not empty and unique.",
-			)
+			return nil, handleDBError(err, "Invalid location name. Ensure new name is not empty and unique.")
 		}
 	}
 
@@ -1502,12 +1327,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 		}
 
 	default:
-		l.Err(err).Msgf("querier.CreateSourceEntry(%+v)", csprms)
-
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"Invalid location source. Ensure metadata is NULL or a non-empty JSON object.",
-		)
+		return nil, handleDBError(err, "Invalid location source. Ensure metadata is NULL or a non-empty JSON object.")
 	}
 
 	l.Debug().
@@ -1520,8 +1340,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 	if refreshIsRequired {
 		err = querier.RefreshSourcesMaterializedView(ctx)
 		if err != nil {
-			l.Err(err).Msg("querier.RefreshSourcesMaterializedView()")
-			return nil, status.Error(codes.Internal, "Failed to update sources materialised view")
+			return nil, handleDBError(err, "Failed to update sources materialised view")
 		}
 
 		l.Debug().Msg("refreshed sources materialised view")
@@ -1549,8 +1368,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocationOwner(
 
 	dbGeom, err := querier.ReownGeometry(ctx, params)
 	if err != nil {
-		l.Err(err).Msgf("querier.ReownGeometry(%+v)", params)
-		return nil, status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
+		return nil, handleDBError(err, "Invalid location UUID")
 	}
 
 	l.Debug().
@@ -1560,8 +1378,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocationOwner(
 
 	err = querier.RefreshSourcesMaterializedView(ctx)
 	if err != nil {
-		l.Err(err).Msg("querier.RefreshSourcesMaterializedView()")
-		return nil, status.Error(codes.Internal, "Failed to update sources materialised view")
+		return nil, handleDBError(err, "Failed to update sources materialised view")
 	}
 
 	l.Debug().Msg("refreshed sources materialised view")
@@ -1576,8 +1393,6 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationsAsGeoJSON(
 	ctx context.Context,
 	req *pb.GetLocationsAsGeoJSONRequest,
 ) (resp *pb.GetLocationsAsGeoJSONResponse, err error) {
-	l := zerolog.Ctx(ctx)
-
 	querier := db.New(ix.GetTxFromContext(ctx))
 
 	// Get the locations as GeoJSON
@@ -1592,7 +1407,6 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationsAsGeoJSON(
 	for i, id := range req.LocationUuids {
 		locationUuids[i], err = uuid.Parse(id)
 		if err != nil {
-			l.Err(err).Msgf("uuid.Parse(%s)", id)
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid location UUID: %v", err)
 		}
 	}
@@ -1604,8 +1418,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationsAsGeoJSON(
 
 	geojson, err := querier.GetGeometryGeoJSON(ctx, ggprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetLocationGeoJSONByIds(%+v)", ggprms)
-		return nil, status.Error(codes.InvalidArgument, "No locations found for input IDs")
+		return nil, handleDBError(err, "No locations found for input IDs")
 	}
 
 	return &pb.GetLocationsAsGeoJSONResponse{Geojson: string(geojson)}, nil
@@ -1630,12 +1443,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetSourceAtTimestamp(%+v)", gsprms)
-
-		return nil, status.Error(
-			codes.NotFound, "No such location. Ensure the location exists, "+
-				"and is operational at the start of the requested time window.",
-		)
+		return nil, handleDBError(err, "No such location. Ensure the location exists, and is operational at the start of the requested time window.")
 	}
 
 	// If in init time has been requested, only return the values for that single forecast.
@@ -1657,12 +1465,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 		dbPreds, err := querier.ListPredictionsForForecasts(ctx, llprms)
 		if err != nil {
-			l.Err(err).Msgf("querier.ListPredictionsForForecasts(%+v)", llprms)
-
-			return nil, status.Error(
-				codes.InvalidArgument,
-				"No forecasts found for the given parameters.",
-			)
+			return nil, handleDBError(err, "No forecasts found for the given parameters.")
 		}
 
 		out := make([]*pb.GetForecastAsTimeseriesResponse_Value, len(dbPreds))
@@ -1721,18 +1524,13 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, gpprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.GetForecasterElseLatest(%+v)", gpprms)
-
-		return nil, status.Error(
-			codes.NotFound, "No such forecaster.",
-		)
+		return nil, handleDBError(err, "No such forecaster.")
 	}
 
 	// Get the predictions for the given location source
 	start, end, err := timeWindowToPgWindow(req.TimeWindow)
 	if err != nil {
-		l.Err(err).Msgf("timeWindowToPgWindow(%+v)", req.TimeWindow)
-		return nil, status.Error(codes.InvalidArgument, "Invalid time window.")
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid time window: %v", err)
 	}
 
 	pivotTime := pgtype.Timestamp{Valid: false}
@@ -1752,12 +1550,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbValues, err := querier.ListPredictionsForLocation(ctx, lpprms)
 	if err != nil {
-		l.Err(err).Msgf("querier.ListPredictionsForLocation(%+v)", lpprms)
-
-		return nil, status.Error(
-			codes.Internal,
-			"Error communicating with backend.",
-		)
+		return nil, handleDBError(err, "Error communicating with backend.")
 	}
 
 	if len(dbValues) == 0 {
@@ -1865,22 +1658,22 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 
 		glResp, err := querier.ListSourcesAtTimestampWithin(ctx, llprms)
 		if err != nil {
-			l.Err(err).Msgf("querier.ListSourcesAtTimestampWithin(%+v)", llprms)
-		} else {
-			for _, loc := range glResp {
-				locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
-					LocationUuid: loc.GeometryUuid.String(),
-					LocationName: loc.GeometryName,
-					Latlng: &pb.LatLng{
-						Latitude:  loc.Latitude,
-						Longitude: loc.Longitude,
-					},
-					EffectiveCapacityWatts: uint64(loc.CapacityWatts),
-					EnergySource:           pb.EnergySource(loc.SourceTypeID),
-					LocationType:           pb.LocationType(loc.GeometryTypeID),
-					Metadata:               loc.MetadataJsonb,
-				})
-			}
+			return nil, handleDBError(err, "Failed to list enclosed locations")
+		}
+
+		for _, loc := range glResp {
+			locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
+				LocationUuid: loc.GeometryUuid.String(),
+				LocationName: loc.GeometryName,
+				Latlng: &pb.LatLng{
+					Latitude:  loc.Latitude,
+					Longitude: loc.Longitude,
+				},
+				EffectiveCapacityWatts: uint64(loc.CapacityWatts),
+				EnergySource:           pb.EnergySource(loc.SourceTypeID),
+				LocationType:           pb.LocationType(loc.GeometryTypeID),
+				Metadata:               loc.MetadataJsonb,
+			})
 		}
 	} else if req.EnclosedLocationUuidFilter != nil {
 		llprms := db.ListSourcesAtTimestampWithoutParams{
@@ -1894,22 +1687,22 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 
 		glResp, err := querier.ListSourcesAtTimestampWithout(ctx, llprms)
 		if err != nil {
-			l.Err(err).Msgf("querier.ListSourcesAtTimestampWithout(%+v)", llprms)
-		} else {
-			for _, loc := range glResp {
-				locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
-					LocationUuid: loc.GeometryUuid.String(),
-					LocationName: loc.GeometryName,
-					Latlng: &pb.LatLng{
-						Latitude:  loc.Latitude,
-						Longitude: loc.Longitude,
-					},
-					EffectiveCapacityWatts: uint64(loc.CapacityWatts),
-					EnergySource:           pb.EnergySource(loc.SourceTypeID),
-					LocationType:           pb.LocationType(loc.GeometryTypeID),
-					Metadata:               loc.MetadataJsonb,
-				})
-			}
+			return nil, handleDBError(err, "Failed to list enclosing locations")
+		}
+
+		for _, loc := range glResp {
+			locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
+				LocationUuid: loc.GeometryUuid.String(),
+				LocationName: loc.GeometryName,
+				Latlng: &pb.LatLng{
+					Latitude:  loc.Latitude,
+					Longitude: loc.Longitude,
+				},
+				EffectiveCapacityWatts: uint64(loc.CapacityWatts),
+				EnergySource:           pb.EnergySource(loc.SourceTypeID),
+				LocationType:           pb.LocationType(loc.GeometryTypeID),
+				Metadata:               loc.MetadataJsonb,
+			})
 		}
 	} else {
 		lsprms := db.ListSourcesAtTimestampParams{
@@ -1923,22 +1716,22 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 
 		glResp, err := querier.ListSourcesAtTimestamp(ctx, lsprms)
 		if err != nil {
-			l.Err(err).Msgf("querier.ListSourcesAtTimestamp(%+v)", lsprms)
-		} else {
-			for _, loc := range glResp {
-				locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
-					LocationUuid: loc.GeometryUuid.String(),
-					LocationName: loc.GeometryName,
-					Latlng: &pb.LatLng{
-						Latitude:  loc.Latitude,
-						Longitude: loc.Longitude,
-					},
-					EffectiveCapacityWatts: uint64(loc.CapacityWatts),
-					EnergySource:           pb.EnergySource(loc.SourceTypeID),
-					LocationType:           pb.LocationType(loc.GeometryTypeID),
-					Metadata:               loc.MetadataJsonb,
-				})
-			}
+			return nil, handleDBError(err, "Failed to list locations")
+		}
+
+		for _, loc := range glResp {
+			locations = append(locations, &pb.ListLocationsResponse_LocationSummary{
+				LocationUuid: loc.GeometryUuid.String(),
+				LocationName: loc.GeometryName,
+				Latlng: &pb.LatLng{
+					Latitude:  loc.Latitude,
+					Longitude: loc.Longitude,
+				},
+				EffectiveCapacityWatts: uint64(loc.CapacityWatts),
+				EnergySource:           pb.EnergySource(loc.SourceTypeID),
+				LocationType:           pb.LocationType(loc.GeometryTypeID),
+				Metadata:               loc.MetadataJsonb,
+			})
 		}
 	}
 

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -29,29 +28,6 @@ import (
 )
 
 // --- Reuseable Functions for Route Logic -------------------------------------------------------
-
-// handleDBError maps database errors to appropriate gRPC status codes.
-func handleDBError(err error, msg string) error {
-	if errors.Is(err, pgx.ErrNoRows) {
-		return status.Errorf(codes.NotFound, "%s: %v", msg, err)
-	}
-
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
-		switch pgErr.Code {
-		case "23505": // unique_violation
-			return status.Errorf(codes.AlreadyExists, "%s: %v", msg, err)
-		case "23503": // foreign_key_violation
-			return status.Errorf(codes.FailedPrecondition, "%s: %v", msg, err)
-		case "23514",
-			"23502",
-			"22P02": // check_violation, not_null_violation, invalid_text_representation
-			return status.Errorf(codes.InvalidArgument, "%s: %v", msg, err)
-		}
-	}
-
-	return status.Errorf(codes.Internal, "%s: %v", msg, err)
-}
 
 // timeWindowToPgWindow converts a TimeWindow protobuf message to a pair of pgtype.Timestamp values.
 func timeWindowToPgWindow(
@@ -131,10 +107,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No location found. Ensure the location exists, and has a registered capacity value for the given energy type valid for before the forecast init time.",
-		)
+		return nil, fmt.Errorf("No location found: %w", err)
 	}
 
 	l.Debug().Str("dp.geometry.uuid", dbSource.GeometryUuid.String()).
@@ -163,10 +136,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No such forecaster. Create the forecaster before submitting a forecast.",
-		)
+		return nil, fmt.Errorf("No such forecaster: %w", err)
 	}
 
 	l.Debug().
@@ -191,10 +161,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecast, err := querier.CreateForecast(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid forecast. Ensure the forecast has a valid init_time and horizon values.",
-		)
+		return nil, fmt.Errorf("Invalid forecast: %w", err)
 	}
 
 	// Create the forecast data
@@ -219,10 +186,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 			err = errors.New("inserted count less than requested")
 		}
 
-		return nil, handleDBError(
-			err,
-			"Invalid predicted generation values. Ensure the values are positive and correspond to less than 110% of capacity.",
-		)
+		return nil, fmt.Errorf("Invalid predicted generation values: %w", err)
 	}
 
 	l.Debug().
@@ -255,10 +219,7 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No such forecaster. Create the forecaster before submitting a forecast.",
-		)
+		return nil, fmt.Errorf("No such forecaster: %w", err)
 	}
 
 	// Delete the forecast
@@ -271,7 +232,7 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 
 	err = querier.DeleteForecast(ctx, dfcprms)
 	if err != nil {
-		return nil, handleDBError(err, "Could not delete forecast. Ensure the forecast exists.")
+		return nil, fmt.Errorf("could not delete forecast: %w", err)
 	}
 
 	return &pb.DeleteForecastResponse{}, nil
@@ -296,10 +257,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestForecasts(
 
 	dbListForecasts, err := querier.GetLatestForecastsAtHorizonSincePivot(ctx, glfprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No forecasts found. Ensure location exists and forecasts have been created for it.",
-		)
+		return nil, fmt.Errorf("No forecasts found: %w", err)
 	}
 
 	l.Debug().Str("dp.geometry.uuid", req.LocationUuid).
@@ -355,10 +313,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid forecaster. Ensure name and version are not empty and are lowercase",
-		)
+		return nil, fmt.Errorf("Invalid forecaster: %w", err)
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -386,7 +341,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateForecaster(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, gpprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such forecaster. Use the create method to add it.")
+		return nil, fmt.Errorf("no such forecaster: %w", err)
 	}
 
 	// Update the forecaster
@@ -397,10 +352,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid forecaster. Ensure name and version are not empty and are lowercase, and name is unique.",
-		)
+		return nil, fmt.Errorf("Invalid forecaster: %w", err)
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -427,7 +379,7 @@ func (s *DataPlatformDataServiceServerImpl) ListForecasters(
 
 	dbListForecasters, err := querier.GetForecastersByFilters(ctx, lfprms)
 	if err != nil {
-		return nil, handleDBError(err, "No forecasters found with the specified filters")
+		return nil, fmt.Errorf("no forecasters found with the specified filters: %w", err)
 	}
 
 	forecasters := make([]*pb.Forecaster, len(dbListForecasters))
@@ -505,7 +457,7 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 					fVersions,
 				)
 				if err != nil {
-					return handleDBError(err, "Failed to stream predictions")
+					return fmt.Errorf("failed to stream predictions: %w", err)
 				}
 				defer rows.Close()
 
@@ -666,13 +618,11 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gstprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no location source found for name '%s' with source type '%s': %w",
+			req.LocationUuid,
+			req.EnergySource,
 			err,
-			fmt.Sprintf(
-				"No location source found for name '%s' with source type '%s'",
-				req.LocationUuid,
-				req.EnergySource,
-			),
 		)
 	}
 
@@ -684,13 +634,11 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no forecaster found for name '%s' and version '%s': %w",
+			req.Forecaster.ForecasterName,
+			req.Forecaster.ForecasterVersion,
 			err,
-			fmt.Sprintf(
-				"No forecaster found for name '%s' and version '%s'",
-				req.Forecaster.ForecasterName,
-				req.Forecaster.ForecasterVersion,
-			),
 		)
 	}
 
@@ -699,12 +647,10 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no observer of name '%s' found: %w",
+			req.ObserverName,
 			err,
-			fmt.Sprintf(
-				"No observer of name '%s' found. Choose an existing observer or create a new one.",
-				req.ObserverName,
-			),
 		)
 	}
 
@@ -719,14 +665,12 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbDeltas, err := querier.GetWeekAverageDeltasForLocations(ctx, avgprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no deltas found for location '%s' with source type '%s' and observer ID '%s': %w",
+			req.LocationUuid,
+			req.EnergySource,
+			dbObserver.ObserverUuid.String(),
 			err,
-			fmt.Sprintf(
-				"No deltas found for location '%s' with source type '%s' and observer ID '%s'",
-				req.LocationUuid,
-				req.EnergySource,
-				dbObserver.ObserverUuid.String(),
-			),
 		)
 	}
 
@@ -760,12 +704,10 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 
 	observerResp, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no observer of name '%s' found: %w",
+			req.ObserverName,
 			err,
-			fmt.Sprintf(
-				"No observer of name '%s' found. Choose an existing observer or create a new one.",
-				req.ObserverName,
-			),
 		)
 	}
 
@@ -784,9 +726,10 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 
 	dbObs, err := querier.GetObservationsBetween(ctx, goprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no observations found for location '%s': %w",
+			req.LocationUuid,
 			err,
-			fmt.Sprintf("No observations found for location '%s'", req.LocationUuid),
 		)
 	}
 
@@ -827,13 +770,11 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no location found for name '%s' with source type '%s': %w",
+			req.LocationUuid,
+			req.EnergySource,
 			err,
-			fmt.Sprintf(
-				"No location found for name '%s' with source type '%s'",
-				req.LocationUuid,
-				req.EnergySource,
-			),
 		)
 	}
 
@@ -842,12 +783,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no observer of name '%s' found: %w",
+			req.ObserverName,
 			err,
-			fmt.Sprintf(
-				"No observer of name '%s', found. Choose an existing observer or create a new one.",
-				req.ObserverName,
-			),
 		)
 	}
 
@@ -870,10 +809,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	err = batch.Close()
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid observation values. Ensure the values are positive, and less than 110% of capacity.",
-		)
+		return nil, fmt.Errorf("Invalid observation values: %w", err)
 	}
 
 	l.Debug().Int16("dp.source.type_id", dbSource.SourceTypeID).
@@ -917,7 +853,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestObservations(
 
 	dbObs, err := querier.GetLatestObservations(ctx, goprms)
 	if err != nil {
-		return nil, handleDBError(err, "Backend communication error")
+		return nil, fmt.Errorf("backend communication error: %w", err)
 	}
 
 	observations := make([]*pb.GetLatestObservationsResponse_Observation, len(dbObs))
@@ -951,10 +887,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObserver(
 
 	dbObserver, err := querier.CreateObserver(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid observer name. Ensure it is not empty, unique, and lowercase",
-		)
+		return nil, fmt.Errorf("Invalid observer name: %w", err)
 	}
 
 	return &pb.CreateObserverResponse{
@@ -976,7 +909,7 @@ func (s *DataPlatformDataServiceServerImpl) ListObservers(
 
 	dbListObservers, err := querier.GetObserversByFilters(ctx, loPrms)
 	if err != nil {
-		return nil, handleDBError(err, "Backend communication error")
+		return nil, fmt.Errorf("backend communication error: %w", err)
 	}
 
 	l.Debug().
@@ -1017,13 +950,11 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no forecaster found for name '%s' and version '%s': %w",
+			req.Forecaster.ForecasterName,
+			req.Forecaster.ForecasterVersion,
 			err,
-			fmt.Sprintf(
-				"No forecaster found for name '%s' and version '%s'",
-				req.Forecaster.ForecasterName,
-				req.Forecaster.ForecasterVersion,
-			),
 		)
 	}
 
@@ -1048,10 +979,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbPredictions, err := querier.ListPredictionsAtTimeForLocations(ctx, lpprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No predicted values found for the specified locations at the given time.",
-		)
+		return nil, fmt.Errorf("No predicted values found for the specified locations at the given time.,: %w", err)
 	}
 
 	values := make([]*pb.GetForecastAtTimestampResponse_Value, len(dbPredictions))
@@ -1124,12 +1052,10 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(
+		return nil, fmt.Errorf(
+			"no observer of name '%s' found: %w",
+			req.ObserverName,
 			err,
-			fmt.Sprintf(
-				"No observer of name '%s' found. Choose an existing observer or create a new one.",
-				req.ObserverName,
-			),
 		)
 	}
 
@@ -1142,10 +1068,7 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObs, err := querier.ListObservationsAtTimeForLocations(ctx, loprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No observations found for the specified locations at the given time. Ensure the observer exists, and that the location is operational.",
-		)
+		return nil, fmt.Errorf("No observations found for the specified locations at the given time: %w", err)
 	}
 
 	observations := make([]*pb.GetObservationsAtTimestampResponse_Value, len(dbObs))
@@ -1188,10 +1111,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No such location. Ensure the location exists and is currently operational.",
-		)
+		return nil, fmt.Errorf("No such location: %w", err)
 	}
 
 	l.Debug().
@@ -1209,7 +1129,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 
 		dbGeometry, err := querier.GetGeometryWKB(ctx, gwkbprms)
 		if err != nil {
-			return nil, handleDBError(err, "Failed to retrieve geometry for location")
+			return nil, fmt.Errorf("failed to retrieve geometry for location: %w", err)
 		}
 
 		geometry = dbGeometry.GeomWkb
@@ -1251,10 +1171,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
 
 	dbValues, err := querier.GetSourceHistory(ctx, gprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No such location or no history for location in the specified time window. Ensure the location exists and has source entries in the given time window.",
-		)
+		return nil, fmt.Errorf("No such location or no history for location in the specified time window: %w", err)
 	}
 
 	values := make([]*pb.GetLocationAsTimeseriesResponse_LocationSnapshot, len(dbValues))
@@ -1298,10 +1215,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbLocation, err := querier.CreateGeometry(ctx, cgprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid location. Ensure name is not empty, and that geometry is valid, closed, unique WGS84.",
-		)
+		return nil, fmt.Errorf("Invalid location: %w", err)
 	}
 
 	l.Debug().
@@ -1328,10 +1242,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbSource, err := querier.CreateSourceEntry(ctx, csprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Invalid location. Ensure metadata is NULL or a non-empty JSON object.",
-		)
+		return nil, fmt.Errorf("Invalid location: %w", err)
 	}
 
 	l.Debug().
@@ -1343,7 +1254,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	err = querier.RefreshSourcesMaterializedView(ctx)
 	if err != nil {
-		return nil, handleDBError(err, "Failed to update sources materialised view")
+		return nil, fmt.Errorf("failed to update sources materialised view: %w", err)
 	}
 
 	l.Debug().Msg("refreshed sources materialised view")
@@ -1386,10 +1297,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, lsprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"Location does not exist. Create the location before attempting to update capacity.",
-		)
+		return nil, fmt.Errorf("Location does not exist: %w", err)
 	}
 
 	l.Debug().
@@ -1419,10 +1327,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 		_, err = querier.RenameGeometry(ctx, rgprms)
 		if err != nil {
-			return nil, handleDBError(
-				err,
-				"Invalid location name. Ensure new name is not empty and unique.",
-			)
+			return nil, fmt.Errorf("Invalid location name: %w", err)
 		}
 	}
 
@@ -1451,10 +1356,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 		}
 
 	default:
-		return nil, handleDBError(
-			err,
-			"Invalid location source. Ensure metadata is NULL or a non-empty JSON object.",
-		)
+		return nil, fmt.Errorf("Invalid location source: %w", err)
 	}
 
 	l.Debug().
@@ -1467,7 +1369,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 	if refreshIsRequired {
 		err = querier.RefreshSourcesMaterializedView(ctx)
 		if err != nil {
-			return nil, handleDBError(err, "Failed to update sources materialised view")
+			return nil, fmt.Errorf("failed to update sources materialised view: %w", err)
 		}
 
 		l.Debug().Msg("refreshed sources materialised view")
@@ -1495,7 +1397,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocationOwner(
 
 	dbGeom, err := querier.ReownGeometry(ctx, params)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid location UUID")
+		return nil, fmt.Errorf("invalid location UUID: %w", err)
 	}
 
 	l.Debug().
@@ -1505,7 +1407,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocationOwner(
 
 	err = querier.RefreshSourcesMaterializedView(ctx)
 	if err != nil {
-		return nil, handleDBError(err, "Failed to update sources materialised view")
+		return nil, fmt.Errorf("failed to update sources materialised view: %w", err)
 	}
 
 	l.Debug().Msg("refreshed sources materialised view")
@@ -1545,7 +1447,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationsAsGeoJSON(
 
 	geojson, err := querier.GetGeometryGeoJSON(ctx, ggprms)
 	if err != nil {
-		return nil, handleDBError(err, "No locations found for input IDs")
+		return nil, fmt.Errorf("no locations found for input IDs: %w", err)
 	}
 
 	return &pb.GetLocationsAsGeoJSONResponse{Geojson: string(geojson)}, nil
@@ -1570,10 +1472,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		return nil, handleDBError(
-			err,
-			"No such location. Ensure the location exists, and is operational at the start of the requested time window.",
-		)
+		return nil, fmt.Errorf("No such location: %w", err)
 	}
 
 	// If in init time has been requested, only return the values for that single forecast.
@@ -1595,7 +1494,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 		dbPreds, err := querier.ListPredictionsForForecasts(ctx, llprms)
 		if err != nil {
-			return nil, handleDBError(err, "No forecasts found for the given parameters.")
+			return nil, fmt.Errorf("no forecasts found for the given parameters: %w", err)
 		}
 
 		out := make([]*pb.GetForecastAsTimeseriesResponse_Value, len(dbPreds))
@@ -1654,7 +1553,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, gpprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such forecaster.")
+		return nil, fmt.Errorf("no such forecaster: %w", err)
 	}
 
 	// Get the predictions for the given location source
@@ -1680,7 +1579,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbValues, err := querier.ListPredictionsForLocation(ctx, lpprms)
 	if err != nil {
-		return nil, handleDBError(err, "Error communicating with backend.")
+		return nil, fmt.Errorf("error communicating with backend: %w", err)
 	}
 
 	if len(dbValues) == 0 {
@@ -1788,7 +1687,7 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 
 		glResp, err := querier.ListSourcesAtTimestampWithin(ctx, llprms)
 		if err != nil {
-			return nil, handleDBError(err, "Failed to list enclosed locations")
+			return nil, fmt.Errorf("failed to list enclosed locations: %w", err)
 		}
 
 		for _, loc := range glResp {
@@ -1817,7 +1716,7 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 
 		glResp, err := querier.ListSourcesAtTimestampWithout(ctx, llprms)
 		if err != nil {
-			return nil, handleDBError(err, "Failed to list enclosing locations")
+			return nil, fmt.Errorf("failed to list enclosing locations: %w", err)
 		}
 
 		for _, loc := range glResp {
@@ -1846,7 +1745,7 @@ func (s *DataPlatformDataServiceServerImpl) ListLocations(
 
 		glResp, err := querier.ListSourcesAtTimestamp(ctx, lsprms)
 		if err != nil {
-			return nil, handleDBError(err, "Failed to list locations")
+			return nil, fmt.Errorf("failed to list locations: %w", err)
 		}
 
 		for _, loc := range glResp {

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -43,7 +43,9 @@ func handleDBError(err error, msg string) error {
 			return status.Errorf(codes.AlreadyExists, "%s: %v", msg, err)
 		case "23503": // foreign_key_violation
 			return status.Errorf(codes.FailedPrecondition, "%s: %v", msg, err)
-		case "23514", "23502", "22P02": // check_violation, not_null_violation, invalid_text_representation
+		case "23514",
+			"23502",
+			"22P02": // check_violation, not_null_violation, invalid_text_representation
 			return status.Errorf(codes.InvalidArgument, "%s: %v", msg, err)
 		}
 	}
@@ -129,7 +131,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		return nil, handleDBError(err, "No location found. Ensure the location exists, and has a registered capacity value for the given energy type valid for before the forecast init time.")
+		return nil, handleDBError(
+			err,
+			"No location found. Ensure the location exists, and has a registered capacity value for the given energy type valid for before the forecast init time.",
+		)
 	}
 
 	l.Debug().Str("dp.geometry.uuid", dbSource.GeometryUuid.String()).
@@ -158,7 +163,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such forecaster. Create the forecaster before submitting a forecast.")
+		return nil, handleDBError(
+			err,
+			"No such forecaster. Create the forecaster before submitting a forecast.",
+		)
 	}
 
 	l.Debug().
@@ -183,7 +191,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecast, err := querier.CreateForecast(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid forecast. Ensure the forecast has a valid init_time and horizon values.")
+		return nil, handleDBError(
+			err,
+			"Invalid forecast. Ensure the forecast has a valid init_time and horizon values.",
+		)
 	}
 
 	// Create the forecast data
@@ -207,7 +218,11 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 		if err == nil {
 			err = errors.New("inserted count less than requested")
 		}
-		return nil, handleDBError(err, "Invalid predicted generation values. Ensure the values are positive and correspond to less than 110% of capacity.")
+
+		return nil, handleDBError(
+			err,
+			"Invalid predicted generation values. Ensure the values are positive and correspond to less than 110% of capacity.",
+		)
 	}
 
 	l.Debug().
@@ -240,7 +255,10 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such forecaster. Create the forecaster before submitting a forecast.")
+		return nil, handleDBError(
+			err,
+			"No such forecaster. Create the forecaster before submitting a forecast.",
+		)
 	}
 
 	// Delete the forecast
@@ -278,7 +296,10 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestForecasts(
 
 	dbListForecasts, err := querier.GetLatestForecastsAtHorizonSincePivot(ctx, glfprms)
 	if err != nil {
-		return nil, handleDBError(err, "No forecasts found. Ensure location exists and forecasts have been created for it.")
+		return nil, handleDBError(
+			err,
+			"No forecasts found. Ensure location exists and forecasts have been created for it.",
+		)
 	}
 
 	l.Debug().Str("dp.geometry.uuid", req.LocationUuid).
@@ -334,7 +355,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid forecaster. Ensure name and version are not empty and are lowercase")
+		return nil, handleDBError(
+			err,
+			"Invalid forecaster. Ensure name and version are not empty and are lowercase",
+		)
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -373,7 +397,10 @@ func (s *DataPlatformDataServiceServerImpl) UpdateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid forecaster. Ensure name and version are not empty and are lowercase, and name is unique.")
+		return nil, handleDBError(
+			err,
+			"Invalid forecaster. Ensure name and version are not empty and are lowercase, and name is unique.",
+		)
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -505,7 +532,11 @@ func (s *DataPlatformDataServiceServerImpl) StreamForecastData(
 						&row.TargetTimeUtc,
 					)
 					if err != nil {
-						return status.Errorf(codes.Internal, "Error reading prediction stream: %v", err)
+						return status.Errorf(
+							codes.Internal,
+							"Error reading prediction stream: %v",
+							err,
+						)
 					}
 
 					otherStatistics := make(map[string]float32)
@@ -635,7 +666,14 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gstprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No location source found for name '%s' with source type '%s'", req.LocationUuid, req.EnergySource))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No location source found for name '%s' with source type '%s'",
+				req.LocationUuid,
+				req.EnergySource,
+			),
+		)
 	}
 
 	// Get the relevant forecaster
@@ -646,7 +684,14 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbExistingForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No forecaster found for name '%s' and version '%s'", req.Forecaster.ForecasterName, req.Forecaster.ForecasterVersion))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No forecaster found for name '%s' and version '%s'",
+				req.Forecaster.ForecasterName,
+				req.Forecaster.ForecasterVersion,
+			),
+		)
 	}
 
 	// Get the observer
@@ -654,7 +699,13 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s' found. Choose an existing observer or create a new one.", req.ObserverName))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No observer of name '%s' found. Choose an existing observer or create a new one.",
+				req.ObserverName,
+			),
+		)
 	}
 
 	// Get the deltas
@@ -668,7 +719,15 @@ func (s *DataPlatformDataServiceServerImpl) GetWeekAverageDeltas(
 
 	dbDeltas, err := querier.GetWeekAverageDeltasForLocations(ctx, avgprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No deltas found for location '%s' with source type '%s' and observer ID '%s'", req.LocationUuid, req.EnergySource, dbObserver.ObserverUuid.String()))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No deltas found for location '%s' with source type '%s' and observer ID '%s'",
+				req.LocationUuid,
+				req.EnergySource,
+				dbObserver.ObserverUuid.String(),
+			),
+		)
 	}
 
 	// Convert the deltas to the response format
@@ -701,7 +760,13 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 
 	observerResp, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s' found. Choose an existing observer or create a new one.", req.ObserverName))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No observer of name '%s' found. Choose an existing observer or create a new one.",
+				req.ObserverName,
+			),
+		)
 	}
 
 	start, end, err := timeWindowToPgWindow(req.TimeWindow)
@@ -719,7 +784,10 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAsTimeseries(
 
 	dbObs, err := querier.GetObservationsBetween(ctx, goprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No observations found for location '%s'", req.LocationUuid))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf("No observations found for location '%s'", req.LocationUuid),
+		)
 	}
 
 	values := make([]*pb.GetObservationsAsTimeseriesResponse_Value, len(dbObs))
@@ -759,7 +827,14 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No location found for name '%s' with source type '%s'", req.LocationUuid, req.EnergySource))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No location found for name '%s' with source type '%s'",
+				req.LocationUuid,
+				req.EnergySource,
+			),
+		)
 	}
 
 	// Get the observer ID
@@ -767,7 +842,13 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s', found. Choose an existing observer or create a new one.", req.ObserverName))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No observer of name '%s', found. Choose an existing observer or create a new one.",
+				req.ObserverName,
+			),
+		)
 	}
 
 	// Insert the observations
@@ -789,7 +870,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	err = batch.Close()
 	if err != nil {
-		return nil, handleDBError(err, "Invalid observation values. Ensure the values are positive, and less than 110% of capacity.")
+		return nil, handleDBError(
+			err,
+			"Invalid observation values. Ensure the values are positive, and less than 110% of capacity.",
+		)
 	}
 
 	l.Debug().Int16("dp.source.type_id", dbSource.SourceTypeID).
@@ -867,7 +951,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateObserver(
 
 	dbObserver, err := querier.CreateObserver(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid observer name. Ensure it is not empty, unique, and lowercase")
+		return nil, handleDBError(
+			err,
+			"Invalid observer name. Ensure it is not empty, unique, and lowercase",
+		)
 	}
 
 	return &pb.CreateObserverResponse{
@@ -930,7 +1017,14 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No forecaster found for name '%s' and version '%s'", req.Forecaster.ForecasterName, req.Forecaster.ForecasterVersion))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No forecaster found for name '%s' and version '%s'",
+				req.Forecaster.ForecasterName,
+				req.Forecaster.ForecasterVersion,
+			),
+		)
 	}
 
 	l.Debug().
@@ -954,7 +1048,10 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbPredictions, err := querier.ListPredictionsAtTimeForLocations(ctx, lpprms)
 	if err != nil {
-		return nil, handleDBError(err, "No predicted values found for the specified locations at the given time.")
+		return nil, handleDBError(
+			err,
+			"No predicted values found for the specified locations at the given time.",
+		)
 	}
 
 	values := make([]*pb.GetForecastAtTimestampResponse_Value, len(dbPredictions))
@@ -1027,7 +1124,13 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObserver, err := querier.GetObserverByName(ctx, obprms)
 	if err != nil {
-		return nil, handleDBError(err, fmt.Sprintf("No observer of name '%s' found. Choose an existing observer or create a new one.", req.ObserverName))
+		return nil, handleDBError(
+			err,
+			fmt.Sprintf(
+				"No observer of name '%s' found. Choose an existing observer or create a new one.",
+				req.ObserverName,
+			),
+		)
 	}
 
 	loprms := db.ListObservationsAtTimeForLocationsParams{
@@ -1039,7 +1142,10 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObs, err := querier.ListObservationsAtTimeForLocations(ctx, loprms)
 	if err != nil {
-		return nil, handleDBError(err, "No observations found for the specified locations at the given time. Ensure the observer exists, and that the location is operational.")
+		return nil, handleDBError(
+			err,
+			"No observations found for the specified locations at the given time. Ensure the observer exists, and that the location is operational.",
+		)
 	}
 
 	observations := make([]*pb.GetObservationsAtTimestampResponse_Value, len(dbObs))
@@ -1082,7 +1188,10 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such location. Ensure the location exists and is currently operational.")
+		return nil, handleDBError(
+			err,
+			"No such location. Ensure the location exists and is currently operational.",
+		)
 	}
 
 	l.Debug().
@@ -1142,7 +1251,10 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
 
 	dbValues, err := querier.GetSourceHistory(ctx, gprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such location or no history for location in the specified time window. Ensure the location exists and has source entries in the given time window.")
+		return nil, handleDBError(
+			err,
+			"No such location or no history for location in the specified time window. Ensure the location exists and has source entries in the given time window.",
+		)
 	}
 
 	values := make([]*pb.GetLocationAsTimeseriesResponse_LocationSnapshot, len(dbValues))
@@ -1186,7 +1298,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbLocation, err := querier.CreateGeometry(ctx, cgprms)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid location. Ensure name is not empty, and that geometry is valid, closed, unique WGS84.")
+		return nil, handleDBError(
+			err,
+			"Invalid location. Ensure name is not empty, and that geometry is valid, closed, unique WGS84.",
+		)
 	}
 
 	l.Debug().
@@ -1213,7 +1328,10 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbSource, err := querier.CreateSourceEntry(ctx, csprms)
 	if err != nil {
-		return nil, handleDBError(err, "Invalid location. Ensure metadata is NULL or a non-empty JSON object.")
+		return nil, handleDBError(
+			err,
+			"Invalid location. Ensure metadata is NULL or a non-empty JSON object.",
+		)
 	}
 
 	l.Debug().
@@ -1268,7 +1386,10 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, lsprms)
 	if err != nil {
-		return nil, handleDBError(err, "Location does not exist. Create the location before attempting to update capacity.")
+		return nil, handleDBError(
+			err,
+			"Location does not exist. Create the location before attempting to update capacity.",
+		)
 	}
 
 	l.Debug().
@@ -1298,7 +1419,10 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 		_, err = querier.RenameGeometry(ctx, rgprms)
 		if err != nil {
-			return nil, handleDBError(err, "Invalid location name. Ensure new name is not empty and unique.")
+			return nil, handleDBError(
+				err,
+				"Invalid location name. Ensure new name is not empty and unique.",
+			)
 		}
 	}
 
@@ -1327,7 +1451,10 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 		}
 
 	default:
-		return nil, handleDBError(err, "Invalid location source. Ensure metadata is NULL or a non-empty JSON object.")
+		return nil, handleDBError(
+			err,
+			"Invalid location source. Ensure metadata is NULL or a non-empty JSON object.",
+		)
 	}
 
 	l.Debug().
@@ -1443,7 +1570,10 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		return nil, handleDBError(err, "No such location. Ensure the location exists, and is operational at the start of the requested time window.")
+		return nil, handleDBError(
+			err,
+			"No such location. Ensure the location exists, and is operational at the start of the requested time window.",
+		)
 	}
 
 	// If in init time has been requested, only return the values for that single forecast.

--- a/internal/server/postgres/dataserverimpl.go
+++ b/internal/server/postgres/dataserverimpl.go
@@ -107,7 +107,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		return nil, fmt.Errorf("No location found: %w", err)
+		return nil, fmt.Errorf("no location found: %w", err)
 	}
 
 	l.Debug().Str("dp.geometry.uuid", dbSource.GeometryUuid.String()).
@@ -136,7 +136,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, fmt.Errorf("No such forecaster: %w", err)
+		return nil, fmt.Errorf("no such forecaster: %w", err)
 	}
 
 	l.Debug().
@@ -161,7 +161,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 
 	dbForecast, err := querier.CreateForecast(ctx, cfprms)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid forecast: %w", err)
+		return nil, fmt.Errorf("invalid forecast: %w", err)
 	}
 
 	// Create the forecast data
@@ -186,7 +186,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecast(
 			err = errors.New("inserted count less than requested")
 		}
 
-		return nil, fmt.Errorf("Invalid predicted generation values: %w", err)
+		return nil, fmt.Errorf("invalid predicted generation values: %w", err)
 	}
 
 	l.Debug().
@@ -219,7 +219,7 @@ func (s *DataPlatformDataServiceServerImpl) DeleteForecast(
 
 	dbForecaster, err := querier.GetForecasterElseLatest(ctx, pctprms)
 	if err != nil {
-		return nil, fmt.Errorf("No such forecaster: %w", err)
+		return nil, fmt.Errorf("no such forecaster: %w", err)
 	}
 
 	// Delete the forecast
@@ -257,7 +257,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLatestForecasts(
 
 	dbListForecasts, err := querier.GetLatestForecastsAtHorizonSincePivot(ctx, glfprms)
 	if err != nil {
-		return nil, fmt.Errorf("No forecasts found: %w", err)
+		return nil, fmt.Errorf("no forecasts found: %w", err)
 	}
 
 	l.Debug().Str("dp.geometry.uuid", req.LocationUuid).
@@ -302,7 +302,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecaster(
 	if err == nil {
 		return nil, status.Errorf(
 			codes.AlreadyExists,
-			"Forecaster with already exists (at version '%s'). "+
+			"Forecaster already exists (at version '%s'). "+
 				"Use the update method to add a new version, or create a new forecaster.",
 			dbExistingForecaster.ForecasterVersion,
 		)
@@ -313,7 +313,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid forecaster: %w", err)
+		return nil, fmt.Errorf("invalid forecaster: %w", err)
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -352,7 +352,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateForecaster(
 
 	dbForecaster, err := querier.CreateForecaster(ctx, cfprms)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid forecaster: %w", err)
+		return nil, fmt.Errorf("invalid forecaster: %w", err)
 	}
 
 	l.Debug().Int32("dp.forecaster.id", dbForecaster.ForecasterID).
@@ -809,7 +809,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObservations(
 
 	err = batch.Close()
 	if err != nil {
-		return nil, fmt.Errorf("Invalid observation values: %w", err)
+		return nil, fmt.Errorf("invalid observation values: %w", err)
 	}
 
 	l.Debug().Int16("dp.source.type_id", dbSource.SourceTypeID).
@@ -887,7 +887,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateObserver(
 
 	dbObserver, err := querier.CreateObserver(ctx, obprms)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid observer name: %w", err)
+		return nil, fmt.Errorf("invalid observer name: %w", err)
 	}
 
 	return &pb.CreateObserverResponse{
@@ -979,7 +979,10 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAtTimestamp(
 
 	dbPredictions, err := querier.ListPredictionsAtTimeForLocations(ctx, lpprms)
 	if err != nil {
-		return nil, fmt.Errorf("No predicted values found for the specified locations at the given time.,: %w", err)
+		return nil, fmt.Errorf(
+			"no predicted values found for the specified locations at the given time.,: %w",
+			err,
+		)
 	}
 
 	values := make([]*pb.GetForecastAtTimestampResponse_Value, len(dbPredictions))
@@ -1068,7 +1071,10 @@ func (s *DataPlatformDataServiceServerImpl) GetObservationsAtTimestamp(
 
 	dbObs, err := querier.ListObservationsAtTimeForLocations(ctx, loprms)
 	if err != nil {
-		return nil, fmt.Errorf("No observations found for the specified locations at the given time: %w", err)
+		return nil, fmt.Errorf(
+			"no observations found for the specified locations at the given time: %w",
+			err,
+		)
 	}
 
 	observations := make([]*pb.GetObservationsAtTimestampResponse_Value, len(dbObs))
@@ -1111,7 +1117,7 @@ func (s *DataPlatformDataServiceServerImpl) GetLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, cfprms)
 	if err != nil {
-		return nil, fmt.Errorf("No such location: %w", err)
+		return nil, fmt.Errorf("no such location: %w", err)
 	}
 
 	l.Debug().
@@ -1171,7 +1177,10 @@ func (s *DataPlatformDataServiceServerImpl) GetLocationAsTimeseries(
 
 	dbValues, err := querier.GetSourceHistory(ctx, gprms)
 	if err != nil {
-		return nil, fmt.Errorf("No such location or no history for location in the specified time window: %w", err)
+		return nil, fmt.Errorf(
+			"no such location or no history for location in the specified time window: %w",
+			err,
+		)
 	}
 
 	values := make([]*pb.GetLocationAsTimeseriesResponse_LocationSnapshot, len(dbValues))
@@ -1215,7 +1224,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbLocation, err := querier.CreateGeometry(ctx, cgprms)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid location: %w", err)
+		return nil, fmt.Errorf("invalid location: %w", err)
 	}
 
 	l.Debug().
@@ -1242,7 +1251,7 @@ func (s *DataPlatformDataServiceServerImpl) CreateLocation(
 
 	dbSource, err := querier.CreateSourceEntry(ctx, csprms)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid location: %w", err)
+		return nil, fmt.Errorf("invalid location: %w", err)
 	}
 
 	l.Debug().
@@ -1297,7 +1306,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, lsprms)
 	if err != nil {
-		return nil, fmt.Errorf("Location does not exist: %w", err)
+		return nil, fmt.Errorf("location does not exist: %w", err)
 	}
 
 	l.Debug().
@@ -1327,7 +1336,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 
 		_, err = querier.RenameGeometry(ctx, rgprms)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid location name: %w", err)
+			return nil, fmt.Errorf("invalid location name: %w", err)
 		}
 	}
 
@@ -1356,7 +1365,7 @@ func (s *DataPlatformDataServiceServerImpl) UpdateLocation(
 		}
 
 	default:
-		return nil, fmt.Errorf("Invalid location source: %w", err)
+		return nil, fmt.Errorf("invalid location source: %w", err)
 	}
 
 	l.Debug().
@@ -1472,7 +1481,7 @@ func (s *DataPlatformDataServiceServerImpl) GetForecastAsTimeseries(
 
 	dbSource, err := querier.GetSourceAtTimestamp(ctx, gsprms)
 	if err != nil {
-		return nil, fmt.Errorf("No such location: %w", err)
+		return nil, fmt.Errorf("no such location: %w", err)
 	}
 
 	// If in init time has been requested, only return the values for that single forecast.


### PR DESCRIPTION
Modifies the returned errors to transparently passthrough errors from the database. This was not done initially as there were thoughts that this might be user facing at one point. Since it is entirely internal, we do not have to worry about leaking implementation details via errors.

### Contribution Checklist

- [x] Have you followed the Open Climate Fix [Contribution Guidelines](https://github.com/openclimatefix#github-contributions)?
- [x] Have you referenced the [Issue](https://github.com/openclimatefix/data-platform/issues) this PR addresses, where applicable?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openclimatefix/data-platform/pulls) for the same change?
- [x] Have you added a summary of the changes?
- [x] Have you written new tests for your changes, where applicable?
- [x] Have you successfully run `make lint` with your changes locally?
- [x] Have you successfully run `make test` with your changes locally?

> [!Warning]
> PRs may be closed if all the above boxes are not checked.

Closes #178 